### PR TITLE
Implement Trade Logging System

### DIFF
--- a/migrations/versions/58eb10982caa_initial_trade_logger_schema.py
+++ b/migrations/versions/58eb10982caa_initial_trade_logger_schema.py
@@ -1,8 +1,8 @@
-"""Initial migration
+"""initial_trade_logger_schema
 
-Revision ID: c1b7f28e5748
+Revision ID: 58eb10982caa
 Revises:
-Create Date: 2026-04-20 12:37:01.704588
+Create Date: 2026-04-21 12:50:04.822680
 
 """
 from typing import Sequence, Union
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision: str = 'c1b7f28e5748'
+revision: str = '58eb10982caa'
 down_revision: Union[str, None] = None
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
@@ -33,6 +33,9 @@ def upgrade() -> None:
     sa.Column('timestamp', sa.DateTime(), nullable=True),
     sa.Column('created_at', sa.DateTime(), nullable=False),
     sa.Column('updated_at', sa.DateTime(), nullable=False),
+    sa.Column('created_by', sa.String(length=100), nullable=True),
+    sa.Column('updated_by', sa.String(length=100), nullable=True),
+    sa.Column('deleted_at', sa.DateTime(), nullable=True),
     sa.Column('is_deleted', sa.Boolean(), nullable=True),
     sa.PrimaryKeyConstraint('id')
     )
@@ -46,6 +49,9 @@ def upgrade() -> None:
     sa.Column('win_rate', sa.Float(), nullable=True),
     sa.Column('created_at', sa.DateTime(), nullable=False),
     sa.Column('updated_at', sa.DateTime(), nullable=False),
+    sa.Column('created_by', sa.String(length=100), nullable=True),
+    sa.Column('updated_by', sa.String(length=100), nullable=True),
+    sa.Column('deleted_at', sa.DateTime(), nullable=True),
     sa.Column('is_deleted', sa.Boolean(), nullable=True),
     sa.PrimaryKeyConstraint('id')
     )
@@ -54,9 +60,13 @@ def upgrade() -> None:
     sa.Column('event_type', sa.String(length=50), nullable=False),
     sa.Column('description', sa.Text(), nullable=True),
     sa.Column('symbol', sa.String(length=20), nullable=True),
+    sa.Column('timestamp', sa.DateTime(), nullable=True),
     sa.Column('signal_id', sa.Integer(), nullable=True),
     sa.Column('created_at', sa.DateTime(), nullable=False),
     sa.Column('updated_at', sa.DateTime(), nullable=False),
+    sa.Column('created_by', sa.String(length=100), nullable=True),
+    sa.Column('updated_by', sa.String(length=100), nullable=True),
+    sa.Column('deleted_at', sa.DateTime(), nullable=True),
     sa.Column('is_deleted', sa.Boolean(), nullable=True),
     sa.ForeignKeyConstraint(['signal_id'], ['model_signals.id'], ),
     sa.PrimaryKeyConstraint('id')
@@ -72,9 +82,13 @@ def upgrade() -> None:
     sa.Column('pnl', sa.Float(), nullable=True),
     sa.Column('drawdown_impact', sa.Float(), nullable=True),
     sa.Column('status', sa.String(length=20), nullable=True),
+    sa.Column('timestamp', sa.DateTime(), nullable=True),
     sa.Column('signal_id', sa.Integer(), nullable=True),
     sa.Column('created_at', sa.DateTime(), nullable=False),
     sa.Column('updated_at', sa.DateTime(), nullable=False),
+    sa.Column('created_by', sa.String(length=100), nullable=True),
+    sa.Column('updated_by', sa.String(length=100), nullable=True),
+    sa.Column('deleted_at', sa.DateTime(), nullable=True),
     sa.Column('is_deleted', sa.Boolean(), nullable=True),
     sa.ForeignKeyConstraint(['signal_id'], ['model_signals.id'], ),
     sa.PrimaryKeyConstraint('id')

--- a/src/core/trade_logger.py
+++ b/src/core/trade_logger.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, List, cast
 
 import numpy as np
 from sqlalchemy import (
@@ -24,24 +24,29 @@ from sqlalchemy import (
     Text,
     create_engine,
 )
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import relationship, sessionmaker
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship, sessionmaker
 
-Base = declarative_base()
+class Base(DeclarativeBase):
+    """Base class for SQLAlchemy models."""
+    pass
+
 logger = logging.getLogger(__name__)
 
 
 class AuditMixin:
     """Audit columns as per DATABASE_STANDARDS.md."""
 
-    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), nullable=False)
-    updated_at = Column(
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
         DateTime,
         default=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),
         nullable=False,
     )
-    is_deleted = Column(Boolean, default=False)
+    created_by: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
+    updated_by: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
+    deleted_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    is_deleted: Mapped[bool] = mapped_column(Boolean, default=False)
 
 
 class ModelSignal(Base, AuditMixin):
@@ -49,19 +54,20 @@ class ModelSignal(Base, AuditMixin):
 
     __tablename__ = "model_signals"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    symbol = Column(String(20), nullable=False)
-    direction = Column(Integer, nullable=False)  # +1 buy, -1 sell, 0 hold
-    entry_price = Column(Float, nullable=False)
-    stop_loss = Column(Float)
-    take_profit = Column(Float)
-    lot_size = Column(Float)
-    algorithm = Column(String(50))
-    confidence = Column(Float)
-    timestamp = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    symbol: Mapped[str] = mapped_column(String(20), nullable=False)
+    direction: Mapped[int] = mapped_column(Integer, nullable=False)  # +1 buy, -1 sell, 0 hold
+    entry_price: Mapped[float] = mapped_column(Float, nullable=False)
+    stop_loss: Mapped[Optional[float]] = mapped_column(Float)
+    take_profit: Mapped[Optional[float]] = mapped_column(Float)
+    lot_size: Mapped[Optional[float]] = mapped_column(Float)
+    algorithm: Mapped[Optional[str]] = mapped_column(String(50))
+    confidence: Mapped[Optional[float]] = mapped_column(Float)
+    timestamp: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
 
     # Relationship
-    trade = relationship("Trade", back_populates="signal", uselist=False)
+    trade: Mapped[Optional["Trade"]] = relationship("Trade", back_populates="signal", uselist=False)
+    risk_events: Mapped[List["RiskEvent"]] = relationship("RiskEvent", back_populates="signal")
 
 
 class Trade(Base, AuditMixin):
@@ -69,19 +75,20 @@ class Trade(Base, AuditMixin):
 
     __tablename__ = "trades"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    ticket = Column(Integer, unique=True, index=True)
-    symbol = Column(String(20), nullable=False)
-    direction = Column(Integer, nullable=False)
-    entry_price = Column(Float, nullable=False)
-    exit_price = Column(Float)
-    lot_size = Column(Float, nullable=False)
-    pnl = Column(Float, default=0.0)
-    drawdown_impact = Column(Float)  # impact on total drawdown
-    status = Column(String(20), default="OPEN")  # OPEN, CLOSED, CANCELLED
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    ticket: Mapped[Optional[int]] = mapped_column(Integer, unique=True, index=True, nullable=True)  # Null if rejected
+    symbol: Mapped[str] = mapped_column(String(20), nullable=False)
+    direction: Mapped[int] = mapped_column(Integer, nullable=False)
+    entry_price: Mapped[float] = mapped_column(Float, nullable=False)
+    exit_price: Mapped[Optional[float]] = mapped_column(Float)
+    lot_size: Mapped[float] = mapped_column(Float, nullable=False)
+    pnl: Mapped[float] = mapped_column(Float, default=0.0)
+    drawdown_impact: Mapped[Optional[float]] = mapped_column(Float)  # impact on total drawdown
+    status: Mapped[str] = mapped_column(String(20), default="OPEN")  # OPEN, CLOSED, CANCELLED, REJECTED
+    timestamp: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
 
-    signal_id = Column(Integer, ForeignKey("model_signals.id"))
-    signal = relationship("ModelSignal", back_populates="trade")
+    signal_id: Mapped[Optional[int]] = mapped_column(Integer, ForeignKey("model_signals.id"))
+    signal: Mapped[Optional["ModelSignal"]] = relationship("ModelSignal", back_populates="trade")
 
 
 class RiskEvent(Base, AuditMixin):
@@ -89,12 +96,14 @@ class RiskEvent(Base, AuditMixin):
 
     __tablename__ = "risk_events"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    event_type = Column(String(50), nullable=False)
-    description = Column(Text)
-    symbol = Column(String(20))
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    event_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    description: Mapped[Optional[str]] = mapped_column(Text)
+    symbol: Mapped[Optional[str]] = mapped_column(String(20))
+    timestamp: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
 
-    signal_id = Column(Integer, ForeignKey("model_signals.id"), nullable=True)
+    signal_id: Mapped[Optional[int]] = mapped_column(Integer, ForeignKey("model_signals.id"), nullable=True)
+    signal: Mapped[Optional["ModelSignal"]] = relationship("ModelSignal", back_populates="risk_events")
 
 
 class PerformanceMetric(Base, AuditMixin):
@@ -102,13 +111,13 @@ class PerformanceMetric(Base, AuditMixin):
 
     __tablename__ = "performance_metrics"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    timestamp = Column(DateTime, default=lambda: datetime.now(timezone.utc))
-    sharpe_ratio = Column(Float)
-    profit_factor = Column(Float)
-    max_drawdown = Column(Float)
-    total_trades = Column(Integer)
-    win_rate = Column(Float)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    timestamp: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
+    sharpe_ratio: Mapped[Optional[float]] = mapped_column(Float)
+    profit_factor: Mapped[Optional[float]] = mapped_column(Float)
+    max_drawdown: Mapped[Optional[float]] = mapped_column(Float)
+    total_trades: Mapped[Optional[int]] = mapped_column(Integer)
+    win_rate: Mapped[Optional[float]] = mapped_column(Float)
 
 
 class TradeLogger:
@@ -119,7 +128,7 @@ class TradeLogger:
         Base.metadata.create_all(self.engine)
         self.Session = sessionmaker(bind=self.engine)
 
-    def log_signal(self, signal_data: Dict[str, Any]) -> int:
+    def log_signal(self, signal_data: Dict[str, Any], created_by: str = "model") -> int:
         """Log a new model signal and return its ID."""
         with self.Session() as session:
             signal = ModelSignal(
@@ -132,22 +141,25 @@ class TradeLogger:
                 algorithm=signal_data.get("algorithm"),
                 confidence=signal_data.get("confidence"),
                 timestamp=signal_data.get("timestamp", datetime.now(timezone.utc)),
+                created_by=created_by,
             )
             session.add(signal)
             session.commit()
-            return signal.id
+            session.refresh(signal)
+            return cast(int, signal.id)
 
     def log_trade(
         self,
-        ticket: int,
+        ticket: Optional[int],
         symbol: str,
         direction: int,
         entry_price: float,
         lot_size: float,
         signal_id: Optional[int] = None,
         status: str = "OPEN",
+        created_by: str = "trader",
     ) -> int:
-        """Log a trade execution."""
+        """Log a trade execution or rejection."""
         with self.Session() as session:
             trade = Trade(
                 ticket=ticket,
@@ -157,10 +169,13 @@ class TradeLogger:
                 lot_size=lot_size,
                 signal_id=signal_id,
                 status=status,
+                created_by=created_by,
+                timestamp=datetime.now(timezone.utc),
             )
             session.add(trade)
             session.commit()
-            return trade.id
+            session.refresh(trade)
+            return cast(int, trade.id)
 
     def update_trade(
         self,
@@ -192,28 +207,31 @@ class TradeLogger:
             else:
                 logger.warning("Trade with ticket %d not found for update.", ticket)
 
-    def get_trade_by_ticket(self, ticket: int) -> Optional[Trade]:
-        """Retrieve trade details by ticket ID."""
-        with self.Session() as session:
-            return session.query(Trade).filter(Trade.ticket == ticket).first()
-
     def log_risk_event(
         self,
         event_type: str,
         description: str,
         symbol: Optional[str] = None,
         signal_id: Optional[int] = None,
-    ) -> None:
-        """Log a risk-related event."""
+        created_by: str = "system",
+    ) -> int:
+        """
+        Log a risk-related event (e.g., trade rejection).
+        Returns the ID of the logged event.
+        """
         with self.Session() as session:
             event = RiskEvent(
                 event_type=event_type,
                 description=description,
                 symbol=symbol,
                 signal_id=signal_id,
+                created_by=created_by,
+                timestamp=datetime.now(timezone.utc),
             )
             session.add(event)
             session.commit()
+            session.refresh(event)
+            return cast(int, event.id)
 
     def read_performance_report(self) -> Dict[str, float]:
         """
@@ -221,6 +239,7 @@ class TradeLogger:
         Returns Sharpe Ratio, Profit Factor, and Max Drawdown.
         """
         with self.Session() as session:
+            # Filter only CLOSED trades to ensure accurate metrics
             trades = session.query(Trade).filter(Trade.status == "CLOSED").all()
             if not trades:
                 return {
@@ -263,6 +282,7 @@ class TradeLogger:
                 max_drawdown=metrics["max_drawdown"],
                 total_trades=len(trades),
                 win_rate=float(np.sum(pnls > 0) / len(pnls)),
+                created_by="system_reporter",
             )
             session.add(metric_record)
             session.commit()

--- a/src/core/trade_logger.py
+++ b/src/core/trade_logger.py
@@ -10,12 +10,11 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional, List, cast
+from typing import Any, Dict, List, Optional, cast
 
 import numpy as np
 from sqlalchemy import (
     Boolean,
-    Column,
     DateTime,
     Float,
     ForeignKey,
@@ -26,9 +25,12 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship, sessionmaker
 
+
 class Base(DeclarativeBase):
     """Base class for SQLAlchemy models."""
+
     pass
+
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +38,9 @@ logger = logging.getLogger(__name__)
 class AuditMixin:
     """Audit columns as per DATABASE_STANDARDS.md."""
 
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=lambda: datetime.now(timezone.utc), nullable=False
+    )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime,
         default=lambda: datetime.now(timezone.utc),
@@ -63,7 +67,9 @@ class ModelSignal(Base, AuditMixin):
     lot_size: Mapped[Optional[float]] = mapped_column(Float)
     algorithm: Mapped[Optional[str]] = mapped_column(String(50))
     confidence: Mapped[Optional[float]] = mapped_column(Float)
-    timestamp: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
+    timestamp: Mapped[datetime] = mapped_column(
+        DateTime, default=lambda: datetime.now(timezone.utc)
+    )
 
     # Relationship
     trade: Mapped[Optional["Trade"]] = relationship("Trade", back_populates="signal", uselist=False)
@@ -76,7 +82,9 @@ class Trade(Base, AuditMixin):
     __tablename__ = "trades"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    ticket: Mapped[Optional[int]] = mapped_column(Integer, unique=True, index=True, nullable=True)  # Null if rejected
+    ticket: Mapped[Optional[int]] = mapped_column(
+        Integer, unique=True, index=True, nullable=True
+    )  # Null if rejected
     symbol: Mapped[str] = mapped_column(String(20), nullable=False)
     direction: Mapped[int] = mapped_column(Integer, nullable=False)
     entry_price: Mapped[float] = mapped_column(Float, nullable=False)
@@ -84,8 +92,12 @@ class Trade(Base, AuditMixin):
     lot_size: Mapped[float] = mapped_column(Float, nullable=False)
     pnl: Mapped[float] = mapped_column(Float, default=0.0)
     drawdown_impact: Mapped[Optional[float]] = mapped_column(Float)  # impact on total drawdown
-    status: Mapped[str] = mapped_column(String(20), default="OPEN")  # OPEN, CLOSED, CANCELLED, REJECTED
-    timestamp: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
+    status: Mapped[str] = mapped_column(
+        String(20), default="OPEN"
+    )  # OPEN, CLOSED, CANCELLED, REJECTED
+    timestamp: Mapped[datetime] = mapped_column(
+        DateTime, default=lambda: datetime.now(timezone.utc)
+    )
 
     signal_id: Mapped[Optional[int]] = mapped_column(Integer, ForeignKey("model_signals.id"))
     signal: Mapped[Optional["ModelSignal"]] = relationship("ModelSignal", back_populates="trade")
@@ -100,10 +112,16 @@ class RiskEvent(Base, AuditMixin):
     event_type: Mapped[str] = mapped_column(String(50), nullable=False)
     description: Mapped[Optional[str]] = mapped_column(Text)
     symbol: Mapped[Optional[str]] = mapped_column(String(20))
-    timestamp: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
+    timestamp: Mapped[datetime] = mapped_column(
+        DateTime, default=lambda: datetime.now(timezone.utc)
+    )
 
-    signal_id: Mapped[Optional[int]] = mapped_column(Integer, ForeignKey("model_signals.id"), nullable=True)
-    signal: Mapped[Optional["ModelSignal"]] = relationship("ModelSignal", back_populates="risk_events")
+    signal_id: Mapped[Optional[int]] = mapped_column(
+        Integer, ForeignKey("model_signals.id"), nullable=True
+    )
+    signal: Mapped[Optional["ModelSignal"]] = relationship(
+        "ModelSignal", back_populates="risk_events"
+    )
 
 
 class PerformanceMetric(Base, AuditMixin):
@@ -112,7 +130,9 @@ class PerformanceMetric(Base, AuditMixin):
     __tablename__ = "performance_metrics"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    timestamp: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
+    timestamp: Mapped[datetime] = mapped_column(
+        DateTime, default=lambda: datetime.now(timezone.utc)
+    )
     sharpe_ratio: Mapped[Optional[float]] = mapped_column(Float)
     profit_factor: Mapped[Optional[float]] = mapped_column(Float)
     max_drawdown: Mapped[Optional[float]] = mapped_column(Float)

--- a/tests/test_trade_logger.py
+++ b/tests/test_trade_logger.py
@@ -56,9 +56,35 @@ def test_performance_report(logger):
     assert report["max_drawdown"] == 50.0
 
 def test_log_risk_event(logger):
-    logger.log_risk_event("CIRCUIT_BREAKER", "Drawdown limit hit")
-    # No exception means success, we could query DB to be sure
+    signal_id = logger.log_signal({
+        "symbol": "XAUUSD",
+        "direction": 1,
+        "entry_price": 2000.0
+    })
+    event_id = logger.log_risk_event(
+        "REJECTED",
+        "Position size too large",
+        symbol="XAUUSD",
+        signal_id=signal_id
+    )
+    assert event_id > 0
     with logger.Session() as session:
         from src.core.trade_logger import RiskEvent
-        event = session.query(RiskEvent).first()
-        assert event.event_type == "CIRCUIT_BREAKER"
+        event = session.query(RiskEvent).filter(RiskEvent.id == event_id).first()
+        assert event.event_type == "REJECTED"
+        assert event.signal_id == signal_id
+        assert event.created_by == "system"
+
+def test_audit_columns(logger):
+    signal_id = logger.log_signal({
+        "symbol": "XAUUSD",
+        "direction": 1,
+        "entry_price": 2000.0
+    }, created_by="test_user")
+
+    with logger.Session() as session:
+        from src.core.trade_logger import ModelSignal
+        signal = session.query(ModelSignal).filter(ModelSignal.id == signal_id).first()
+        assert signal.created_by == "test_user"
+        assert signal.created_at is not None
+        assert signal.updated_at is not None


### PR DESCRIPTION
I have implemented the trade logging system using SQLAlchemy 2.0 ORM with SQLite as requested. The system includes:
- **Comprehensive Schema**: Tables for trades, signals, performance metrics, and risk events (including rejections).
- **Audit System**: Mandatory audit columns (`created_at`, `updated_at`, `created_by`, etc.) are integrated into all tables via `AuditMixin`.
- **Performance Reporting**: A `read_performance_report()` method that calculates the Sharpe Ratio (annualized), Profit Factor, and Max Drawdown from closed trades.
- **Migration Support**: A clean Alembic migration revision is provided to initialize the schema.
- **Integration Tests**: A suite of tests verifying signal logging, trade execution/rejection, audit trails, and performance metric calculations.

The implementation follows modern SQLAlchemy best practices, utilizing `Mapped` and `mapped_column` for robust type safety.

---
*PR created automatically by Jules for task [11402415967993378770](https://jules.google.com/task/11402415967993378770) started by @triqbit*