### PR TITLE
Implement 6-layer execution filter cascade

### DIFF
--- a/src/trading/execution_filter.py
+++ b/src/trading/execution_filter.py
@@ -12,7 +12,6 @@ from datetime import datetime, timezone
 from typing import Optional
 
 import pandas as pd
-import pandas_ta as ta
 
 logger = logging.getLogger(__name__)
 
@@ -106,8 +105,16 @@ class ExecutionFilter:
         return ExecutionDecision(signal=signal, confidence_score=confidence)
 
     def _check_atr_volatility(self, df: pd.DataFrame) -> bool:
-        atr = ta.atr(df["high"], df["low"], df["close"], length=self.atr_period)
-        if atr is None or atr.empty:
+        # Calculate True Range manually to avoid pandas-ta dependency in CI
+        high = df["high"]
+        low = df["low"]
+        close_prev = df["close"].shift(1)
+        tr = pd.concat(
+            [high - low, (high - close_prev).abs(), (low - close_prev).abs()], axis=1
+        ).max(axis=1)
+        atr = tr.rolling(window=self.atr_period).mean()
+
+        if atr.empty:
             return False
         current_atr = atr.iloc[-1]
         avg_atr = atr.rolling(window=self.atr_avg_period).mean().iloc[-1]
@@ -118,8 +125,8 @@ class ExecutionFilter:
         return bool(current_atr <= 3 * avg_atr)
 
     def _check_trend_angle(self, df: pd.DataFrame, signal: int) -> bool:
-        ema_med = ta.ema(df["close"], length=self.ema_med)
-        if ema_med is None or len(ema_med) < 2:
+        ema_med = df["close"].ewm(span=self.ema_med, adjust=False).mean()
+        if len(ema_med) < 2:
             return False
 
         slope = ema_med.iloc[-1] - ema_med.iloc[-2]
@@ -130,12 +137,9 @@ class ExecutionFilter:
         return False
 
     def _check_ema_sequence(self, df: pd.DataFrame, signal: int) -> bool:
-        ema_f = ta.ema(df["close"], length=self.ema_fast)
-        ema_m = ta.ema(df["close"], length=self.ema_med)
-        ema_s = ta.ema(df["close"], length=self.ema_slow)
-
-        if ema_f is None or ema_m is None or ema_s is None:
-            return False
+        ema_f = df["close"].ewm(span=self.ema_fast, adjust=False).mean()
+        ema_m = df["close"].ewm(span=self.ema_med, adjust=False).mean()
+        ema_s = df["close"].ewm(span=self.ema_slow, adjust=False).mean()
 
         f, m, s = ema_f.iloc[-1], ema_m.iloc[-1], ema_s.iloc[-1]
 
@@ -149,11 +153,18 @@ class ExecutionFilter:
         return False
 
     def _check_momentum(self, df: pd.DataFrame, signal: int) -> bool:
-        rsi = ta.rsi(df["close"], length=self.rsi_period)
-        if rsi is None or rsi.empty:
-            return False
+        delta = df["close"].diff()
+        up = delta.clip(lower=0)
+        down = -delta.clip(upper=0)
+        ma_up = up.rolling(window=self.rsi_period).mean()
+        ma_down = down.rolling(window=self.rsi_period).mean()
 
-        current_rsi = rsi.iloc[-1]
+        if ma_down.iloc[-1] == 0:
+            current_rsi = 100.0 if ma_up.iloc[-1] != 0 else 50.0
+        else:
+            rs = ma_up.iloc[-1] / ma_down.iloc[-1]
+            current_rsi = 100 - (100 / (1 + rs))
+
         if pd.isna(current_rsi):
             return False
 

--- a/src/trading/execution_filter.py
+++ b/src/trading/execution_filter.py
@@ -1,0 +1,171 @@
+"""
+MT5 AI/ML Trading Bot - Enterprise Edition
+src/trading/execution_filter.py
+6-layer execution filter cascade for signal validation.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Optional
+
+import pandas as pd
+import pandas_ta as ta
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ExecutionDecision:
+    """Outcome of the execution filter cascade."""
+
+    signal: int  # 1: Buy, -1: Sell, 0: Blocked/Hold
+    confidence_score: float
+    blocked_by: Optional[str] = None
+
+
+class ExecutionFilter:
+    """
+    Implements a 6-layer validation cascade:
+    1. ATR Volatility
+    2. Trend Angle
+    3. EMA Sequence
+    4. Momentum Filter
+    5. Session/Time Filter
+    6. Drawdown Circuit Breaker
+    """
+
+    def __init__(
+        self,
+        atr_period: int = 14,
+        atr_avg_period: int = 30,
+        ema_fast: int = 20,
+        ema_med: int = 50,
+        ema_slow: int = 200,
+        rsi_period: int = 14,
+        drawdown_limit: float = 0.15,
+    ):
+        self.atr_period = atr_period
+        self.atr_avg_period = atr_avg_period
+        self.ema_fast = ema_fast
+        self.ema_med = ema_med
+        self.ema_slow = ema_slow
+        self.rsi_period = rsi_period
+        self.drawdown_limit = drawdown_limit
+
+    def validate(
+        self,
+        df: pd.DataFrame,
+        signal: int,
+        confidence: float,
+        drawdown: float,
+        timestamp: Optional[datetime] = None,
+    ) -> ExecutionDecision:
+        """
+        Runs the full 6-layer cascade.
+        """
+        if signal == 0:
+            return ExecutionDecision(signal=0, confidence_score=confidence)
+
+        # 1. ATR Volatility
+        if not self._check_atr_volatility(df):
+            return ExecutionDecision(
+                signal=0, confidence_score=confidence, blocked_by="ATR_VOLATILITY"
+            )
+
+        # 2. Trend Angle (Confirmation)
+        if not self._check_trend_angle(df, signal):
+            return ExecutionDecision(
+                signal=0, confidence_score=confidence, blocked_by="TREND_ANGLE"
+            )
+
+        # 3. EMA Sequence
+        if not self._check_ema_sequence(df, signal):
+            return ExecutionDecision(
+                signal=0, confidence_score=confidence, blocked_by="EMA_SEQUENCE"
+            )
+
+        # 4. Momentum Filter
+        if not self._check_momentum(df, signal):
+            return ExecutionDecision(signal=0, confidence_score=confidence, blocked_by="MOMENTUM")
+
+        # 5. Session/Time Filter
+        if not self._check_session(timestamp):
+            return ExecutionDecision(
+                signal=0, confidence_score=confidence, blocked_by="SESSION_TIME"
+            )
+
+        # 6. Drawdown Circuit Breaker
+        if drawdown >= self.drawdown_limit:
+            return ExecutionDecision(
+                signal=0, confidence_score=confidence, blocked_by="DRAWDOWN_LIMIT"
+            )
+
+        return ExecutionDecision(signal=signal, confidence_score=confidence)
+
+    def _check_atr_volatility(self, df: pd.DataFrame) -> bool:
+        atr = ta.atr(df["high"], df["low"], df["close"], length=self.atr_period)
+        if atr is None or atr.empty:
+            return False
+        current_atr = atr.iloc[-1]
+        avg_atr = atr.rolling(window=self.atr_avg_period).mean().iloc[-1]
+
+        if pd.isna(current_atr) or pd.isna(avg_atr):
+            return True  # Not enough history yet to block
+
+        return bool(current_atr <= 3 * avg_atr)
+
+    def _check_trend_angle(self, df: pd.DataFrame, signal: int) -> bool:
+        ema_med = ta.ema(df["close"], length=self.ema_med)
+        if ema_med is None or len(ema_med) < 2:
+            return False
+
+        slope = ema_med.iloc[-1] - ema_med.iloc[-2]
+        if signal == 1:
+            return bool(slope > 0)
+        if signal == -1:
+            return bool(slope < 0)
+        return False
+
+    def _check_ema_sequence(self, df: pd.DataFrame, signal: int) -> bool:
+        ema_f = ta.ema(df["close"], length=self.ema_fast)
+        ema_m = ta.ema(df["close"], length=self.ema_med)
+        ema_s = ta.ema(df["close"], length=self.ema_slow)
+
+        if ema_f is None or ema_m is None or ema_s is None:
+            return False
+
+        f, m, s = ema_f.iloc[-1], ema_m.iloc[-1], ema_s.iloc[-1]
+
+        if pd.isna(f) or pd.isna(m) or pd.isna(s):
+            return False
+
+        if signal == 1:
+            return bool(f > m > s)
+        if signal == -1:
+            return bool(f < m < s)
+        return False
+
+    def _check_momentum(self, df: pd.DataFrame, signal: int) -> bool:
+        rsi = ta.rsi(df["close"], length=self.rsi_period)
+        if rsi is None or rsi.empty:
+            return False
+
+        current_rsi = rsi.iloc[-1]
+        if pd.isna(current_rsi):
+            return False
+
+        if signal == 1:
+            return bool(current_rsi > 50)
+        if signal == -1:
+            return bool(current_rsi < 50)
+        return False
+
+    def _check_session(self, timestamp: Optional[datetime]) -> bool:
+        if timestamp is None:
+            timestamp = datetime.now(timezone.utc)
+
+        # Weekday: 0=Monday, ..., 5=Saturday, 6=Sunday
+        return bool(timestamp.weekday() < 5)

--- a/tests/test_execution_filter.py
+++ b/tests/test_execution_filter.py
@@ -1,0 +1,102 @@
+from datetime import datetime, timezone
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.trading.execution_filter import ExecutionFilter
+
+
+@pytest.fixture
+def base_df():
+    """Creates a base dataframe with 300 rows of OHLCV data."""
+    dates = pd.date_range(end=datetime.now(), periods=300, freq="5min")
+    df = pd.DataFrame(
+        {
+            "open": np.linspace(1900, 2000, 300),
+            "high": np.linspace(1905, 2005, 300),
+            "low": np.linspace(1895, 1995, 300),
+            "close": np.linspace(1900, 2000, 300),
+            "tick_volume": [100] * 300,
+        },
+        index=dates,
+    )
+    return df
+
+
+class TestExecutionFilter:
+    def test_atr_volatility_pass(self, base_df):
+        ef = ExecutionFilter()
+        # Flat growth means constant small ATR
+        assert ef._check_atr_volatility(base_df) is True
+
+    def test_atr_volatility_fail(self, base_df):
+        ef = ExecutionFilter()
+        # Spiking the last high price to increase ATR
+        df_spike = base_df.copy()
+        df_spike.iloc[-1, df_spike.columns.get_loc("high")] = 3000
+        df_spike.iloc[-1, df_spike.columns.get_loc("low")] = 1000
+        assert ef._check_atr_volatility(df_spike) is False
+
+    def test_trend_angle_buy_pass(self, base_df):
+        ef = ExecutionFilter()
+        # base_df has positive slope (1900 to 2000)
+        assert ef._check_trend_angle(base_df, 1) is True
+
+    def test_trend_angle_buy_fail(self, base_df):
+        ef = ExecutionFilter()
+        # Reversed slope
+        df_rev = base_df.copy()
+        df_rev["close"] = np.linspace(2000, 1900, 300)
+        assert ef._check_trend_angle(df_rev, 1) is False
+
+    def test_ema_sequence_buy_pass(self, base_df):
+        ef = ExecutionFilter()
+        # In a steady uptrend, fast > med > slow usually holds
+        # 20, 50, 200 periods
+        # With np.linspace(1900, 2000), EMA will be f > m > s
+        assert ef._check_ema_sequence(base_df, 1) is True
+
+    def test_ema_sequence_sell_pass(self, base_df):
+        ef = ExecutionFilter()
+        df_down = base_df.copy()
+        df_down["close"] = np.linspace(2000, 1900, 300)
+        assert ef._check_ema_sequence(df_down, -1) is True
+
+    def test_momentum_buy_pass(self, base_df):
+        ef = ExecutionFilter()
+        # Steady uptrend means RSI > 50
+        assert ef._check_momentum(base_df, 1) is True
+
+    def test_momentum_sell_pass(self, base_df):
+        ef = ExecutionFilter()
+        df_down = base_df.copy()
+        df_down["close"] = np.linspace(2000, 1900, 300)
+        assert ef._check_momentum(df_down, -1) is True
+
+    def test_session_pass(self):
+        ef = ExecutionFilter()
+        # Wednesday
+        ts = datetime(2024, 5, 22, 12, 0, tzinfo=timezone.utc)
+        assert ef._check_session(ts) is True
+
+    def test_session_fail(self):
+        ef = ExecutionFilter()
+        # Saturday
+        ts = datetime(2024, 5, 25, 12, 0, tzinfo=timezone.utc)
+        assert ef._check_session(ts) is False
+
+    def test_drawdown_fail(self, base_df):
+        ef = ExecutionFilter()
+        decision = ef.validate(base_df, 1, 0.8, 0.20)
+        assert decision.signal == 0
+        assert decision.blocked_by == "DRAWDOWN_LIMIT"
+
+    def test_full_cascade_pass(self, base_df):
+        ef = ExecutionFilter()
+        # Wednesday
+        ts = datetime(2024, 5, 22, 12, 0, tzinfo=timezone.utc)
+        decision = ef.validate(base_df, 1, 0.85, 0.05, timestamp=ts)
+        assert decision.signal == 1
+        assert decision.blocked_by is None
+        assert decision.confidence_score == 0.85


### PR DESCRIPTION
Implemented the 6-layer execution filter described in README.md inside `src/trading/execution_filter.py`. 

The implementation includes:
1. **ATR Volatility Layer**: Blocks signals when current ATR exceeds 3x its 30-period average.
2. **Trend Angle Layer**: Confirms direction using the slope of a 50-period EMA.
3. **EMA Sequence Layer**: Verifies fast (20), medium (50), and slow (200) EMA alignment.
4. **Momentum Layer**: Uses RSI (14) with a threshold of 50 for trend confirmation.
5. **Session/Time Layer**: Restricts trading to weekdays (Monday-Friday).
6. **Drawdown Layer**: Implements a 15% circuit breaker for account protection.

All filters return a typed `ExecutionDecision` dataclass. Comprehensive unit tests were added in `tests/test_execution_filter.py` to verify each layer individually and the full cascade using mock market data.

---
*PR created automatically by Jules for task [16306233120578681426](https://jules.google.com/task/16306233120578681426) started by @triqbit*