### PR TITLE
Implement 6-layer execution filter

### DIFF
--- a/src/trading/__init__.py
+++ b/src/trading/__init__.py
@@ -2,7 +2,15 @@
 
 from __future__ import annotations
 
+from src.trading.execution_filter import ExecutionDecision, ExecutionFilter
 from src.trading.mt5_connector import MT5Connector
 from src.trading.risk_manager import DailyStats, RiskManager, TradeSignal
 
-__all__ = ["DailyStats", "MT5Connector", "RiskManager", "TradeSignal"]
+__all__ = [
+    "DailyStats",
+    "ExecutionDecision",
+    "ExecutionFilter",
+    "MT5Connector",
+    "RiskManager",
+    "TradeSignal",
+]

--- a/src/trading/execution_filter.py
+++ b/src/trading/execution_filter.py
@@ -1,0 +1,180 @@
+"""
+MT5 AI/ML Trading Bot - Enterprise Edition
+src/trading/execution_filter.py
+6-layer execution validation cascade.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Optional
+
+import pandas as pd
+
+from src.trading.risk_manager import TradeSignal
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ExecutionDecision:
+    """Outcome of the execution filter validation."""
+
+    signal: TradeSignal
+    confidence: float
+    is_approved: bool
+    blocked_by: Optional[str] = None
+
+
+class ExecutionFilter:
+    """
+    Implements a 6-layer validation cascade for trade signals.
+    """
+
+    def __init__(self, drawdown_threshold: float = 0.15) -> None:
+        self.drawdown_threshold = drawdown_threshold
+
+    def validate(
+        self,
+        signal: TradeSignal,
+        indicators: pd.DataFrame,
+        current_drawdown: float,
+        timestamp: Optional[datetime] = None,
+    ) -> ExecutionDecision:
+        """
+        Run the full 6-layer validation cascade.
+        """
+        if indicators.empty:
+            return ExecutionDecision(
+                signal=signal,
+                confidence=0.0,
+                is_approved=False,
+                blocked_by="Missing indicator data",
+            )
+
+        last_row = indicators.iloc[-1]
+        ts = timestamp or datetime.now(timezone.utc)
+
+        # Layer 1: ATR Volatility Block
+        if not self._validate_volatility(last_row):
+            return ExecutionDecision(
+                signal=signal,
+                confidence=signal.confidence * 0.8,
+                is_approved=False,
+                blocked_by="Volatility: ATR too high",
+            )
+
+        # Layer 2: Trend Angle (EMA 50 slope)
+        if not self._validate_trend_angle(indicators, signal.direction):
+            return ExecutionDecision(
+                signal=signal,
+                confidence=signal.confidence * 0.7,
+                is_approved=False,
+                blocked_by="Trend: EMA50 slope mismatch",
+            )
+
+        # Layer 3: EMA Sequence
+        if not self._validate_ema_sequence(last_row, signal.direction):
+            return ExecutionDecision(
+                signal=signal,
+                confidence=signal.confidence * 0.6,
+                is_approved=False,
+                blocked_by="Trend: EMA sequence mismatch",
+            )
+
+        # Layer 4: Momentum (RSI)
+        if not self._validate_momentum(last_row, signal.direction):
+            return ExecutionDecision(
+                signal=signal,
+                confidence=signal.confidence * 0.5,
+                is_approved=False,
+                blocked_by="Momentum: RSI mismatch",
+            )
+
+        # Layer 5: Session Filter
+        if not self._validate_session(ts):
+            return ExecutionDecision(
+                signal=signal,
+                confidence=signal.confidence * 0.9,
+                is_approved=False,
+                blocked_by="Session: Outside market hours",
+            )
+
+        # Layer 6: Drawdown Circuit Breaker
+        if not self._validate_drawdown(current_drawdown):
+            return ExecutionDecision(
+                signal=signal,
+                confidence=0.0,
+                is_approved=False,
+                blocked_by="Risk: Drawdown circuit breaker",
+            )
+
+        return ExecutionDecision(
+            signal=signal,
+            confidence=signal.confidence,
+            is_approved=True,
+        )
+
+    def _validate_volatility(self, row: pd.Series) -> bool:
+        """ATR(14) > 3x MA(100) volatility block."""
+        atr = row.get("atr_14")
+        atr_ma = row.get("atr_14_ma_100")
+        if atr is None or atr_ma is None:
+            return True
+        return atr <= (3 * atr_ma)
+
+    def _validate_trend_angle(self, df: pd.DataFrame, direction: int) -> bool:
+        """50-period EMA slope confirmation."""
+        if len(df) < 2 or "ema_50" not in df.columns:
+            return True
+        ema50_curr = df["ema_50"].iloc[-1]
+        ema50_prev = df["ema_50"].iloc[-2]
+
+        if direction > 0:  # Buy
+            return ema50_curr > ema50_prev
+        elif direction < 0:  # Sell
+            return ema50_curr < ema50_prev
+        return False
+
+    def _validate_ema_sequence(self, row: pd.Series, direction: int) -> bool:
+        """EMA(20) > EMA(50) > EMA(200) for Buy, reverse for Sell."""
+        e20 = row.get("ema_20")
+        e50 = row.get("ema_50")
+        e200 = row.get("ema_200")
+
+        if e20 is None or e50 is None or e200 is None:
+            return True
+
+        if direction > 0:
+            return e20 > e50 > e200
+        elif direction < 0:
+            return e20 < e50 < e200
+        return False
+
+    def _validate_momentum(self, row: pd.Series, direction: int) -> bool:
+        """RSI(14) > 50 (Buy) / < 50 (Sell)."""
+        rsi = row.get("rsi_14")
+        if rsi is None:
+            return True
+
+        if direction > 0:
+            return rsi > 50
+        elif direction < 0:
+            return rsi < 50
+        return False
+
+    def _validate_session(self, ts: datetime) -> bool:
+        """Institutional 08:00-21:00 GMT session filter."""
+        # Ensure we are working with UTC
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        else:
+            ts = ts.astimezone(timezone.utc)
+
+        hour = ts.hour
+        return 8 <= hour < 21
+
+    def _validate_drawdown(self, current_drawdown: float) -> bool:
+        """15% drawdown circuit breaker."""
+        return current_drawdown < self.drawdown_threshold

--- a/tests/test_execution_filter.py
+++ b/tests/test_execution_filter.py
@@ -1,0 +1,122 @@
+
+import pytest
+import pandas as pd
+from datetime import datetime, timezone
+from src.trading.execution_filter import ExecutionFilter, ExecutionDecision
+from src.trading.risk_manager import TradeSignal
+
+@pytest.fixture
+def base_indicators():
+    return pd.DataFrame({
+        "atr_14": [1.0, 1.0],
+        "atr_14_ma_100": [1.0, 1.0],
+        "ema_50": [100.0, 101.0],  # Upward slope
+        "ema_20": [105.0, 106.0],
+        "ema_200": [90.0, 91.0],
+        "rsi_14": [60.0, 60.0]
+    })
+
+@pytest.fixture
+def buy_signal():
+    return TradeSignal(
+        symbol="XAUUSD",
+        direction=1,
+        entry_price=2000.0,
+        stop_loss=1990.0,
+        take_profit=2020.0,
+        lot_size=0.1,
+        algorithm="test",
+        confidence=0.8
+    )
+
+class TestExecutionFilter:
+    def test_layer1_volatility_block(self, buy_signal, base_indicators):
+        filter = ExecutionFilter()
+        # High volatility
+        base_indicators.loc[1, "atr_14"] = 4.0
+        base_indicators.loc[1, "atr_14_ma_100"] = 1.0
+
+        decision = filter.validate(buy_signal, base_indicators, 0.0)
+        assert not decision.is_approved
+        assert "Volatility" in decision.blocked_by
+
+    def test_layer2_trend_angle(self, buy_signal, base_indicators):
+        filter = ExecutionFilter()
+        # Downward slope for buy signal
+        base_indicators.loc[1, "ema_50"] = 99.0
+
+        decision = filter.validate(buy_signal, base_indicators, 0.0)
+        assert not decision.is_approved
+        assert "Trend: EMA50 slope mismatch" in decision.blocked_by
+
+    def test_layer3_ema_sequence(self, buy_signal, base_indicators):
+        filter = ExecutionFilter()
+        # Wrong sequence for buy: 20 < 50
+        base_indicators.loc[1, "ema_20"] = 95.0
+        base_indicators.loc[1, "ema_50"] = 101.0
+
+        decision = filter.validate(buy_signal, base_indicators, 0.0)
+        assert not decision.is_approved
+        assert "Trend: EMA sequence mismatch" in decision.blocked_by
+
+    def test_layer4_momentum(self, buy_signal, base_indicators):
+        filter = ExecutionFilter()
+        # RSI < 50 for buy
+        base_indicators.loc[1, "rsi_14"] = 40.0
+
+        decision = filter.validate(buy_signal, base_indicators, 0.0)
+        assert not decision.is_approved
+        assert "Momentum" in decision.blocked_by
+
+    def test_layer5_session(self, buy_signal, base_indicators):
+        filter = ExecutionFilter()
+        # 03:00 UTC (Outside 08-21)
+        ts = datetime(2023, 1, 1, 3, 0, 0, tzinfo=timezone.utc)
+
+        decision = filter.validate(buy_signal, base_indicators, 0.0, timestamp=ts)
+        assert not decision.is_approved
+        assert "Session" in decision.blocked_by
+
+    def test_layer6_drawdown(self, buy_signal, base_indicators):
+        filter = ExecutionFilter(drawdown_threshold=0.15)
+
+        decision = filter.validate(buy_signal, base_indicators, 0.16)
+        assert not decision.is_approved
+        assert "Drawdown" in decision.blocked_by
+
+    def test_full_cascade_approval(self, buy_signal, base_indicators):
+        filter = ExecutionFilter()
+        ts = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+        decision = filter.validate(buy_signal, base_indicators, 0.05, timestamp=ts)
+        assert decision.is_approved
+        assert decision.blocked_by is None
+        assert decision.confidence == buy_signal.confidence
+
+    def test_sell_signal_validation(self, base_indicators):
+        sell_signal = TradeSignal(
+            symbol="XAUUSD",
+            direction=-1,
+            entry_price=2000.0,
+            stop_loss=2010.0,
+            take_profit=1980.0,
+            lot_size=0.1,
+            algorithm="test",
+            confidence=0.7
+        )
+        # Setup indicators for sell
+        indicators = pd.DataFrame({
+            "atr_14": [1.0, 1.0],
+            "atr_14_ma_100": [1.0, 1.0],
+            "ema_50": [100.0, 99.0],    # Down slope
+            "ema_20": [95.0, 94.0],      # 20 < 50
+            "ema_200": [110.0, 109.0],   # 50 < 200 (Sequence: 20 < 50 < 200)
+            "rsi_14": [40.0, 40.0]       # RSI < 50
+        })
+
+        filter = ExecutionFilter()
+        ts = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        decision = filter.validate(sell_signal, indicators, 0.0, timestamp=ts)
+
+        assert decision.is_approved
+        assert decision.blocked_by is None


### PR DESCRIPTION
This PR implements the 6-layer execution filter described in the README.md. 

The filter cascade includes:
1. ATR volatility block (ATR14 <= 3x MA100)
2. Trend Angle confirmation (EMA50 slope)
3. EMA sequence check (EMA20 > EMA50 > EMA200 for BUY)
4. Momentum filter (RSI14 > 50 for BUY)
5. Session filter (08:00 - 21:00 GMT)
6. Drawdown circuit breaker (15% threshold)

Includes a full suite of unit tests verifying each layer individually and the full cascade for both Buy and Sell signals.

---
*PR created automatically by Jules for task [6836234188371140913](https://jules.google.com/task/6836234188371140913) started by @triqbit*