### PR TITLE
Add model calibration and confidence reliability module

### DIFF
--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,5 +1,18 @@
 """AI/ML models: ensemble systems and neural architectures."""
 
+from src.models.calibration import (
+    CalibrationMetrics,
+    CalibrationReport,
+    ConfidenceBucket,
+    ModelCalibrator,
+)
 from src.models.ensemble import EnsembleModel, LSTMAttentionModel
 
-__all__ = ["EnsembleModel", "LSTMAttentionModel"]
+__all__ = [
+    "CalibrationMetrics",
+    "CalibrationReport",
+    "ConfidenceBucket",
+    "EnsembleModel",
+    "LSTMAttentionModel",
+    "ModelCalibrator",
+]

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,12 +1,33 @@
 """AI/ML models: ensemble systems and neural architectures."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 from src.models.calibration import (
     CalibrationMetrics,
     CalibrationReport,
     ConfidenceBucket,
     ModelCalibrator,
 )
-from src.models.ensemble import EnsembleModel, LSTMAttentionModel
+
+if TYPE_CHECKING:
+    from src.models.ensemble import EnsembleModel, LSTMAttentionModel
+
+_LAZY_IMPORTS = {
+    "EnsembleModel": "src.models.ensemble",
+    "LSTMAttentionModel": "src.models.ensemble",
+}
+
+
+def __getattr__(name: str) -> Any:
+    if name in _LAZY_IMPORTS:
+        import importlib
+
+        module = importlib.import_module(_LAZY_IMPORTS[name])
+        return getattr(module, name)
+    raise AttributeError(f"module {__name__} has no attribute {name}")
+
 
 __all__ = [
     "CalibrationMetrics",

--- a/src/models/calibration.py
+++ b/src/models/calibration.py
@@ -1,0 +1,194 @@
+"""
+MT5 AI/ML Trading Bot - Enterprise Edition
+src/models/calibration.py
+Measuring and improving confidence reliability across model outputs.
+Author : triqbit
+License: MIT
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, List, Optional, Tuple, Union
+
+import numpy as np
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+
+class ConfidenceBucket(BaseModel):
+    """Statistically representative bin for confidence analysis."""
+
+    bin_min: float
+    bin_max: float
+    avg_confidence: float
+    accuracy: float
+    sample_count: int
+
+
+class CalibrationMetrics(BaseModel):
+    """Standardised metrics for model reliability."""
+
+    brier_score: float = Field(..., description="Mean squared error of probabilistic forecasts")
+    ece: float = Field(..., description="Expected Calibration Error (weighted avg diff)")
+    mce: float = Field(..., description="Max Calibration Error (worst bin diff)")
+    reliability_curve: List[ConfidenceBucket]
+
+
+class CalibrationReport(BaseModel):
+    """Institutional-grade calibration summary."""
+
+    algorithm: str
+    metrics: CalibrationMetrics
+    optimal_threshold: float
+    status: str  # e.g., "Well Calibrated", "Overconfident", "Underconfident"
+
+
+class ModelCalibrator:
+    """
+    Measures and analyses model confidence reliability.
+    Supports Brier scoring, ECE, MCE, and threshold optimization.
+    """
+
+    def __init__(self, n_bins: int = 10) -> None:
+        self.n_bins = n_bins
+
+    def calculate_metrics(
+        self,
+        confidences: np.ndarray,
+        outcomes: np.ndarray,
+    ) -> CalibrationMetrics:
+        """
+        Calculate calibration metrics and reliability curve.
+
+        Args:
+            confidences: Array of model confidence scores [0, 1]
+            outcomes: Array of binary outcomes (1 for correct/profitable, 0 otherwise)
+
+        Returns:
+            CalibrationMetrics object
+        """
+        if len(confidences) == 0:
+            return CalibrationMetrics(
+                brier_score=0.0,
+                ece=0.0,
+                mce=0.0,
+                reliability_curve=[],
+            )
+
+        # Brier Score: Mean Squared Error
+        brier_score = float(np.mean((confidences - outcomes) ** 2))
+
+        # Reliability Curve / ECE / MCE
+        bins = np.linspace(0.0, 1.0, self.n_bins + 1)
+        reliability_curve: List[ConfidenceBucket] = []
+
+        ece = 0.0
+        mce = 0.0
+        total_samples = len(confidences)
+
+        for i in range(self.n_bins):
+            bin_min, bin_max = bins[i], bins[i+1]
+            indices = np.where((confidences >= bin_min) & (confidences < bin_max))[0]
+
+            # Handle the last bin edge case
+            if i == self.n_bins - 1:
+                indices = np.where((confidences >= bin_min) & (confidences <= bin_max))[0]
+
+            if len(indices) > 0:
+                bin_conf = confidences[indices]
+                bin_out = outcomes[indices]
+
+                avg_conf = float(np.mean(bin_conf))
+                accuracy = float(np.mean(bin_out))
+                count = len(indices)
+
+                bucket = ConfidenceBucket(
+                    bin_min=float(bin_min),
+                    bin_max=float(bin_max),
+                    avg_confidence=avg_conf,
+                    accuracy=accuracy,
+                    sample_count=count
+                )
+                reliability_curve.append(bucket)
+
+                diff = abs(avg_conf - accuracy)
+                ece += (count / total_samples) * diff
+                mce = max(mce, diff)
+
+        return CalibrationMetrics(
+            brier_score=brier_score,
+            ece=ece,
+            mce=mce,
+            reliability_curve=reliability_curve
+        )
+
+    def find_optimal_threshold(
+        self,
+        confidences: np.ndarray,
+        outcomes: np.ndarray,
+        min_accuracy: float = 0.6
+    ) -> float:
+        """
+        Find the minimum confidence threshold that meets an accuracy target.
+        """
+        thresholds = np.linspace(0.0, 0.95, 20)
+
+        for t in thresholds:
+            mask = confidences >= t
+            if np.any(mask):
+                acc = np.mean(outcomes[mask])
+                if acc >= min_accuracy:
+                    return float(t)
+
+        return 0.0
+
+    def generate_report(
+        self,
+        algorithm: str,
+        confidences: np.ndarray,
+        outcomes: np.ndarray
+    ) -> CalibrationReport:
+        """Generate a full calibration report with automated status detection."""
+        metrics = self.calculate_metrics(confidences, outcomes)
+        optimal_threshold = self.find_optimal_threshold(confidences, outcomes)
+
+        # Simple status logic
+        if metrics.ece < 0.05:
+            status = "Well Calibrated"
+        elif metrics.ece < 0.15:
+            status = "Adequate"
+        else:
+            # Check if overconfident or underconfident
+            avg_conf = np.mean(confidences) if len(confidences) > 0 else 0
+            avg_acc = np.mean(outcomes) if len(outcomes) > 0 else 0
+            if avg_conf > avg_acc + 0.05:
+                status = "Overconfident"
+            elif avg_conf < avg_acc - 0.05:
+                status = "Underconfident"
+            else:
+                status = "Unreliable"
+
+        return CalibrationReport(
+            algorithm=algorithm,
+            metrics=metrics,
+            optimal_threshold=optimal_threshold,
+            status=status
+        )
+
+    def apply_temperature_scaling(
+        self,
+        logits: np.ndarray,
+        temperature: float
+    ) -> np.ndarray:
+        """
+        Simple temperature scaling to soften/harden probabilities.
+        p_i = exp(z_i / T) / sum(exp(z_j / T))
+        """
+        if temperature <= 0:
+            temperature = 1.0
+
+        scaled_logits = logits / temperature
+        exp_logits = np.exp(scaled_logits - np.max(scaled_logits, axis=-1, keepdims=True))
+        return exp_logits / np.sum(exp_logits, axis=-1, keepdims=True)

--- a/src/models/calibration.py
+++ b/src/models/calibration.py
@@ -8,13 +8,10 @@ License: MIT
 
 from __future__ import annotations
 
-import logging
-from typing import Dict, List, Optional, Tuple, Union
+from typing import List
 
 import numpy as np
 from pydantic import BaseModel, Field
-
-logger = logging.getLogger(__name__)
 
 
 class ConfidenceBucket(BaseModel):

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -1,0 +1,72 @@
+import numpy as np
+import pytest
+from src.models.calibration import ModelCalibrator, CalibrationMetrics, CalibrationReport
+
+def test_calculate_metrics_perfect_calibration():
+    calibrator = ModelCalibrator(n_bins=5)
+    # Perfect calibration: confidence equals outcome probability
+    confidences = np.array([0.1, 0.3, 0.5, 0.7, 0.9])
+    outcomes = np.array([0, 0, 1, 1, 1])  # Not exactly matching, but let's use more samples
+
+    confidences = np.repeat([0.2, 0.8], 50)
+    outcomes = np.concatenate([np.zeros(40), np.ones(10), np.zeros(10), np.ones(40)])
+    # 0.2 bin: 10/50 = 0.2 accuracy
+    # 0.8 bin: 40/50 = 0.8 accuracy
+
+    metrics = calibrator.calculate_metrics(confidences, outcomes)
+
+    assert metrics.ece == pytest.approx(0.0, abs=1e-5)
+    assert metrics.mce == pytest.approx(0.0, abs=1e-5)
+    assert len(metrics.reliability_curve) == 2
+
+def test_calculate_metrics_overconfident():
+    calibrator = ModelCalibrator(n_bins=10)
+    confidences = np.array([0.9, 0.9, 0.9])
+    outcomes = np.array([0, 0, 1])  # 33% accuracy for 90% confidence
+
+    metrics = calibrator.calculate_metrics(confidences, outcomes)
+
+    assert metrics.ece > 0.5
+    assert metrics.mce > 0.5
+
+def test_find_optimal_threshold():
+    calibrator = ModelCalibrator()
+    confidences = np.array([0.1, 0.2, 0.5, 0.7, 0.8, 0.9])
+    outcomes = np.array([0, 0, 0, 1, 1, 1])
+
+    # Target 100% accuracy (possible at 0.7+)
+    # np.linspace(0.0, 0.95, 20) -> [0.  , 0.05, 0.1 , 0.15, 0.2 , 0.25, 0.3 , 0.35, 0.4 , 0.45, 0.5 , 0.55, 0.6 , 0.65, 0.7 , 0.75, 0.8 , 0.85, 0.9 , 0.95]
+    # at t=0.55, mask is [0.7, 0.8, 0.9], acc = 1.0. This is the first t >= 0.55 that yields 100% accuracy.
+    # Wait, if t=0.55, then conf >= 0.55 are [0.7, 0.8, 0.9]. All are 1. So acc = 1.0.
+    threshold = calibrator.find_optimal_threshold(confidences, outcomes, min_accuracy=1.0)
+    assert threshold == pytest.approx(0.55, abs=0.01)
+
+def test_generate_report():
+    calibrator = ModelCalibrator()
+    confidences = np.array([0.8, 0.85, 0.9])
+    outcomes = np.array([1, 1, 1])
+
+    report = calibrator.generate_report("test_algo", confidences, outcomes)
+
+    assert report.algorithm == "test_algo"
+    # avg_conf = 0.85, accuracy = 1.0. ECE = 0.15.
+    # Status logic: ECE < 0.05 -> Well, < 0.15 -> Adequate, else Under/Over
+    assert report.status == "Underconfident"
+
+def test_temperature_scaling():
+    calibrator = ModelCalibrator()
+    logits = np.array([[1.0, 2.0, 0.0]])
+
+    # High temperature -> more uniform
+    probs_high_t = calibrator.apply_temperature_scaling(logits, temperature=10.0)
+    assert np.allclose(probs_high_t, [1/3, 1/3, 1/3], atol=0.1)
+
+    # Low temperature -> more sharp
+    probs_low_t = calibrator.apply_temperature_scaling(logits, temperature=0.1)
+    assert probs_low_t[0, 1] > 0.99
+
+def test_empty_input():
+    calibrator = ModelCalibrator()
+    metrics = calibrator.calculate_metrics(np.array([]), np.array([]))
+    assert metrics.ece == 0.0
+    assert metrics.reliability_curve == []


### PR DESCRIPTION
Implemented a robust model calibration module to measure and improve the reliability of confidence scores across trading models. The module includes statistical metrics (Brier score, ECE, MCE), visualization-ready reliability curves, and tools for threshold tuning and temperature scaling. Fully typed and tested.

---
*PR created automatically by Jules for task [17382868287070140132](https://jules.google.com/task/17382868287070140132) started by @saysgrok*