### PR TITLE
Add enterprise-grade operational runbooks

### DIFF
--- a/docs/runbooks/01-ci-failure-recovery.md
+++ b/docs/runbooks/01-ci-failure-recovery.md
@@ -1,0 +1,67 @@
+# Runbook 01: CI Failure Recovery
+
+## Description
+This runbook provides instructions for recovering from failing GitHub Actions CI jobs.
+
+## Failure Scenarios
+
+### 1. Code Quality (Ruff/Linting)
+**Symptom:** CI fails at "Code Quality" job.
+**Step-by-step Instructions:**
+1. Identify the violation from the CI logs.
+2. Run linting locally to reproduce:
+   ```bash
+   ruff check src/ main.py
+   ```
+3. Run formatting check locally:
+   ```bash
+   ruff format --check src/ main.py
+   ```
+4. Fix violations:
+   - For auto-fixable lint issues: `ruff check --fix src/ main.py`
+   - For formatting issues: `ruff format src/ main.py`
+5. Commit and push changes.
+
+**Expected Outcome:** `ruff check` and `ruff format --check` pass with no errors.
+
+### 2. Dependency Safety (pip-audit)
+**Symptom:** CI fails at "Dependency Safety" job due to known CVEs.
+**Step-by-step Instructions:**
+1. Identify the vulnerable package and CVE ID from CI logs.
+2. Run audit locally:
+   ```bash
+   pip-audit --requirement requirements-ci.txt
+   ```
+3. Update the package in `requirements.txt` and `requirements-ci.txt` to a patched version.
+4. If no patch is available, assess risk or find alternative packages.
+5. Commit and push updated requirements.
+
+**Expected Outcome:** `pip-audit` reports "No known vulnerabilities found".
+
+### 3. Tests (pytest)
+**Symptom:** CI fails at "Tests" job.
+**Step-by-step Instructions:**
+1. Identify failing tests from CI logs.
+2. Ensure TA-Lib and other dependencies are installed locally.
+3. Run tests locally:
+   ```bash
+   pytest tests/ --cov=src -v
+   ```
+4. Fix the code or test case causing the failure.
+5. Verify coverage meets the required threshold (e.g., >25%).
+
+**Expected Outcome:** All tests pass and coverage threshold is met.
+
+## Escalation Path
+1. If linting fails on third-party code: Add exclusion to `pyproject.toml`.
+2. If CVE cannot be fixed: Escalate to Security Officer (Jules02).
+3. If tests fail due to environment issues: Escalate to Platform Engineer (Jules03).
+
+## Verification Commands
+```bash
+# Full local CI check
+ruff check src/ main.py
+ruff format --check src/ main.py
+pip-audit --requirement requirements-ci.txt
+pytest tests/ --cov=src -v
+```

--- a/docs/runbooks/02-mt5-connection-outage.md
+++ b/docs/runbooks/02-mt5-connection-outage.md
@@ -1,0 +1,57 @@
+# Runbook 02: MT5 Connection Outage
+
+## Description
+This runbook provides instructions for handling failures in MT5 terminal connection or MetaAPI cloud fallback.
+
+## Troubleshooting Steps
+
+### 1. Verify Native MT5 Connection (Windows)
+**Step-by-step Instructions:**
+1. Check if the MT5 Terminal is running on the host machine.
+2. Verify `MT5_PATH` in `.env` matches the installation path.
+3. Check `MT5_LOGIN`, `MT5_PASSWORD`, and `MT5_SERVER` credentials.
+4. Check MT5 "Journal" tab for connection errors (e.g., "Invalid account", "No connection").
+5. Test connection with a minimal script:
+   ```python
+   import MetaTrader5 as mt5
+   if not mt5.initialize(login=LOGIN, password=PASSWORD, server=SERVER):
+       print("Failed:", mt5.last_error())
+   else:
+       print("Connected")
+       mt5.shutdown()
+   ```
+
+**Expected Outcome:** `mt5.initialize()` returns `True`.
+
+### 2. Verify MetaAPI Fallback (Linux/Mac/Cloud)
+**Step-by-step Instructions:**
+1. Check `METAAPI_TOKEN` and `METAAPI_ACCOUNT_ID` in `.env`.
+2. Verify internet connectivity to MetaAPI endpoints.
+3. Check MetaAPI dashboard for account status (should be `DEPLOYED`).
+4. Check logs for "MetaAPI initialization failed".
+
+**Expected Outcome:** Logs show "MetaAPI fallback configured".
+
+### 3. Check Network Connectivity
+**Step-by-step Instructions:**
+1. Ping the broker's MT5 server address.
+2. Ensure firewall allows outgoing traffic on MT5 ports (usually 443 or specific broker ports).
+3. Check for ISP or Data Center outages.
+
+**Expected Outcome:** Successful ping and open ports.
+
+## Escalation Path
+1. Credentials invalid: Contact Broker Support.
+2. MT5 Terminal crash: Restart Terminal/Server.
+3. MetaAPI platform issue: Check [MetaAPI Status Page](https://status.metaapi.cloud).
+4. Persistent connection loss: Escalate to Trading Lead (Jules01).
+
+## Verification Commands
+```bash
+# Check bot logs for connection status
+grep "MT5" logs/app.log
+
+# Check environment variables
+echo $MT5_SERVER
+echo $MT5_LOGIN
+```

--- a/docs/runbooks/03-circuit-breaker-triggered.md
+++ b/docs/runbooks/03-circuit-breaker-triggered.md
@@ -1,0 +1,44 @@
+# Runbook 03: Circuit Breaker Triggered
+
+## Description
+This runbook provides instructions for responding to risk engine halts triggered by circuit breakers or daily loss limits.
+
+## Trigger Scenarios
+
+### 1. Hard Circuit Breaker (15% Drawdown)
+**Symptom:** Logs show `CIRCUIT BREAKER: drawdown=...% - trading halted`. Telegram alert sent.
+**Step-by-step Instructions:**
+1. **Immediate Action:** Verify all open positions are closed via MT5 Terminal or MetaAPI.
+2. **Audit:** Review `trades` table in `trades.db` to identify the sequence of losing trades.
+   ```sql
+   SELECT * FROM trades ORDER BY created_at DESC LIMIT 20;
+   ```
+3. **Analyze:** Check if the losses were due to model failure, high volatility (slippage), or bug in execution.
+4. **Remediation:** If a bug is found, fix and deploy. If model failure, retrain or adjust parameters.
+5. **Recovery:** To resume trading, the peak equity must be reset or the account balance increased. **Note:** This requires manual intervention and approval from Risk Committee.
+
+**Expected Outcome:** Trading remains halted until manual override.
+
+### 2. Daily Loss Limit Hit
+**Symptom:** Logs show `Daily loss limit hit: ...%`. Signal rejections with reason `Daily loss limit reached`.
+**Step-by-step Instructions:**
+1. Wait for the trading day to end.
+2. Review intraday trades for anomalies.
+3. The bot will automatically resume at the start of the next trading day when `reset_daily()` is called.
+4. If immediate resumption is critical (and approved):
+   - Restart the bot process (this will reset `DailyStats` in memory).
+
+**Expected Outcome:** Bot resumes trading after 00:00 UTC or process restart.
+
+## Escalation Path
+1. Hard Circuit Breaker: MUST escalate to Trading Lead (Jules01) and Risk Manager (Jules03).
+2. Unexpected Daily Loss: Escalate to Quant Strategist (Jules04) to review model performance.
+
+## Verification Commands
+```bash
+# Check risk events in database
+sqlite3 trades.db "SELECT * FROM risk_events WHERE event_type='CIRCUIT_BREAKER';"
+
+# Check current drawdown in logs
+grep "drawdown" logs/app.log | tail -n 5
+```

--- a/docs/runbooks/04-database-corruption.md
+++ b/docs/runbooks/04-database-corruption.md
@@ -1,0 +1,63 @@
+# Runbook 04: Database Corruption Recovery
+
+## Description
+This runbook provides instructions for recovering from SQLite database corruption in `trades.db`.
+
+## Recovery Procedures
+
+### 1. Verification of Corruption
+**Symptom:** Logs show `sqlite3.DatabaseError: database disk image is malformed` or SQLAlchemy `OperationalError`.
+**Step-by-step Instructions:**
+1. Run integrity check:
+   ```bash
+   sqlite3 trades.db "PRAGMA integrity_check;"
+   ```
+2. If it returns anything other than `ok`, the database is corrupt.
+
+**Expected Outcome:** Integrity check identifies corruption.
+
+### 2. Recovery using `.dump` (Best Effort)
+**Step-by-step Instructions:**
+1. Attempt to dump data to a SQL file, ignoring errors:
+   ```bash
+   sqlite3 trades.db ".dump" > dump.sql
+   ```
+2. Create a new database from the dump:
+   ```bash
+   mv trades.db trades.db.bak
+   sqlite3 trades.db < dump.sql
+   ```
+3. Verify integrity of the new database:
+   ```bash
+   sqlite3 trades.db "PRAGMA integrity_check;"
+   ```
+
+**Expected Outcome:** `trades.db` is recreated with most data intact.
+
+### 3. Recovery from Backup
+**Step-by-step Instructions:**
+1. Stop the trading bot process.
+2. Locate the latest backup (e.g., in `backups/` directory if configured, or EBS snapshot).
+3. Restore the backup file:
+   ```bash
+   cp backups/trades.db.latest trades.db
+   ```
+4. Restart the bot.
+
+**Expected Outcome:** Bot resumes with data from the last backup.
+
+## Prevention
+1. Ensure the filesystem has enough space.
+2. Use `WAL` mode for SQLite to improve concurrency and reliability.
+3. Schedule regular backups (see `DEPLOYMENT_GUIDE.md`).
+
+## Escalation Path
+1. Recovery fails: Escalate to Platform Engineer (Jules03) or DBA.
+2. Significant data loss (>1 hour): Notify Compliance/Audit.
+
+## Verification Commands
+```bash
+# Check table counts after recovery
+sqlite3 trades.db "SELECT count(*) FROM trades;"
+sqlite3 trades.db "SELECT count(*) FROM model_signals;"
+```

--- a/docs/runbooks/05-failed-deployment-rollback.md
+++ b/docs/runbooks/05-failed-deployment-rollback.md
@@ -1,0 +1,69 @@
+# Runbook 05: Failed Deployment Rollback
+
+## Description
+This runbook provides instructions for rolling back a bad release in production.
+
+## Rollback Procedures
+
+### 1. Kubernetes Rollback (Automated)
+**Symptom:** New deployment shows high error rate, crashing pods, or failed health checks.
+**Step-by-step Instructions:**
+1. Check rollout history:
+   ```bash
+   kubectl rollout history deployment/trading-bot
+   ```
+2. Undo the rollout to the previous revision:
+   ```bash
+   kubectl rollout undo deployment/trading-bot
+   ```
+3. Monitor status:
+   ```bash
+   kubectl rollout status deployment/trading-bot
+   ```
+
+**Expected Outcome:** Deployment reverts to the previous known-good Docker image.
+
+### 2. Manual Version Revert (Git/CI)
+**Symptom:** Issue discovered after rollout completion.
+**Step-by-step Instructions:**
+1. Identify the last stable commit SHA or Tag (e.g., `v1.1.0`).
+2. Revert the changes in the main branch or point the `production` branch back to the stable commit.
+3. Push changes to trigger CI/CD pipeline.
+   ```bash
+   git checkout main
+   git revert <bad_commit_sha>
+   git push origin main
+   ```
+
+**Expected Outcome:** CI/CD builds and deploys the stable version.
+
+### 3. Database Migration Rollback (If applicable)
+**Symptom:** Rollback of code fails because database schema is incompatible.
+**Step-by-step Instructions:**
+1. Identify the target migration version (revision).
+2. Run Alembic downgrade:
+   ```bash
+   alembic downgrade -1  # Downgrade by one version
+   # OR
+   alembic downgrade <revision_id>
+   ```
+
+**Expected Outcome:** Database schema is reverted to the previous version.
+
+## Post-Rollback Actions
+1. Verify system health and trade execution.
+2. Communicate the incident and rollback status to stakeholders.
+3. Perform a Post-Mortem to identify root cause.
+
+## Escalation Path
+1. Rollback fails: Escalate to SRE / DevOps Lead.
+2. Data corruption during migration rollback: Escalate to DBA.
+
+## Verification Commands
+```bash
+# Check running image version
+kubectl get pods -o jsonpath='{.items[*].spec.containers[*].image}'
+
+# Check Alembic version
+alembic current
+```

--- a/docs/runbooks/06-monitoring-alert-triage.md
+++ b/docs/runbooks/06-monitoring-alert-triage.md
@@ -1,0 +1,46 @@
+# Runbook 06: Monitoring Alert Triage
+
+## Description
+This runbook provides instructions for triaging Telegram alerts sent by the bot.
+
+## Alert Severity Matrix
+
+| Alert Message | Severity | Action Required |
+| :--- | :--- | :--- |
+| `🚨 CRITICAL: Circuit Breaker Triggered!` | **P1 (Critical)** | Immediate stop/verify positions. See Runbook 03. |
+| `⚠️ WARNING: Model Confidence Degradation` | **P2 (High)** | Investigate market conditions. Possible manual halt. |
+| `📅 Daily Summary` | **P4 (Info)** | No action. Review for performance tracking. |
+| `Failed to send Telegram message` (Logs) | **P3 (Medium)** | Check Telegram Bot API status and Token. |
+
+## Triage Steps
+
+### 1. Handling P1 Alerts (Circuit Breaker)
+**Step-by-step Instructions:**
+1. Open MT5 Terminal or Broker App immediately.
+2. Ensure no rogue orders are open.
+3. Check bot logs for the exact drawdown value and time.
+4. Follow **Runbook 03**.
+
+### 2. Handling P2 Alerts (Confidence Degradation)
+**Step-by-step Instructions:**
+1. Check the `current` vs `threshold` confidence in the alert.
+2. If confidence is significantly below threshold (e.g., < 0.4 while threshold is 0.6), consider the market "untradeable" for the current model.
+3. Monitor logs for high signal rejection rate.
+4. Consult with Quant Strategist (Jules04) regarding model retraining.
+
+### 3. Handling P3 Alerts (Alerting System Failure)
+**Step-by-step Instructions:**
+1. If you notice missing daily summaries, check the bot's log for `telegram.error.TelegramError`.
+2. Verify `TELEGRAM_TOKEN` and `TELEGRAM_CHAT_ID` are still valid.
+3. Check internet connectivity from the production server.
+
+## Escalation Path
+1. P1 Alerts: On-call trader and Platform Engineer.
+2. P2 Alerts: Quant Strategist.
+3. Persistent Alerting Failures: Platform Engineer (Jules03).
+
+## Verification Commands
+```bash
+# Check for recent alerts in logs
+grep -E "CRITICAL|WARNING|alert" logs/app.log | tail -n 20
+```

--- a/docs/runbooks/07-secret-rotation-procedure.md
+++ b/docs/runbooks/07-secret-rotation-procedure.md
@@ -1,0 +1,53 @@
+# Runbook 07: Secret Rotation Procedure
+
+## Description
+This runbook provides instructions for rotating secrets (MT5 credentials, MetaAPI tokens, Telegram tokens) safely.
+
+## Rotation Procedures
+
+### 1. MT5 Password Rotation
+**Step-by-step Instructions:**
+1. Change the password in the MetaTrader 5 Terminal or via the Broker's web portal.
+2. Update the `MT5_PASSWORD` value in the production `.env` file or Secret Manager (e.g., Kubernetes Secrets, AWS Secrets Manager).
+3. Restart the bot process to load the new configuration:
+   ```bash
+   kubectl rollout restart deployment/trading-bot
+   ```
+4. Verify logs for "Native MT5 SDK initialized successfully".
+
+**Expected Outcome:** Bot connects using the new password.
+
+### 2. MetaAPI Token Rotation
+**Step-by-step Instructions:**
+1. Generate a new token in the MetaAPI Dashboard.
+2. Update `METAAPI_TOKEN` in the production configuration.
+3. Restart the bot.
+4. Verify fallback connectivity if applicable.
+
+**Expected Outcome:** Bot initializes MetaAPI with the new token.
+
+### 3. Telegram Bot Token Rotation
+**Step-by-step Instructions:**
+1. Use `@BotFather` on Telegram to revoke the old token and generate a new one.
+2. Update `TELEGRAM_TOKEN` in the production configuration.
+3. Restart the bot.
+4. Trigger a test message or wait for the next heartbeat/trade to verify.
+
+**Expected Outcome:** Telegram alerts continue to function.
+
+## Security Best Practices
+1. Never commit `.env` files to Git.
+2. Use environment-specific secrets (Staging vs Production).
+3. Rotate secrets immediately if a compromise is suspected or a team member leaves.
+4. Use minimum-privilege tokens where possible.
+
+## Escalation Path
+1. Lockout after rotation: Contact Broker Support or MetaAPI Support.
+2. Compromised secret: Immediate revocation and escalation to Security Officer (Jules02).
+
+## Verification Commands
+```bash
+# Verify the bot is running after secret update
+kubectl get pods
+kubectl logs -f <pod_name> | grep "initializ"
+```


### PR DESCRIPTION
Added 7 enterprise-grade operational runbooks to the `docs/runbooks/` directory, covering common failure scenarios such as CI failures, MT5 connection issues, risk engine halts, database corruption, deployment rollbacks, alert triage, and secret rotation. Each runbook follows a standardized format with step-by-step instructions and verification commands.

---
*PR created automatically by Jules for task [1241299720848641225](https://jules.google.com/task/1241299720848641225) started by @andonly1348*