### PR TITLE
Add Enterprise Health Check System

### DIFF
--- a/main.py
+++ b/main.py
@@ -23,6 +23,7 @@ from typing import Optional
 import structlog
 
 from src.core.config import get_config
+from src.core.health import startup_health_gate
 from src.core.monitor import Monitor
 from src.core.trade_logger import TradeLogger
 from src.models.ensemble import EnsembleModel
@@ -207,6 +208,14 @@ def main() -> int:
     trade_logger = TradeLogger(
         db_url=cfg.database_url if "sqlite" in cfg.database_url else "sqlite:///trades.db"
     )
+
+    # Startup Health Gate
+    try:
+        startup_health_gate(cfg, connector, trade_logger)
+    except RuntimeError as e:
+        log.critical("System health check failed during startup: %s", e)
+        return 1
+
     risk = RiskManager(cfg, account_balance=balance, logger_db=trade_logger)
     monitor = Monitor(cfg)
     risk = RiskManager(cfg, account_balance=balance, monitor=monitor)

--- a/src/core/health.py
+++ b/src/core/health.py
@@ -11,8 +11,7 @@ import logging
 import shutil
 from datetime import datetime, timezone
 from enum import Enum
-from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, Optional
 
 from pydantic import BaseModel, Field
 from sqlalchemy import text

--- a/src/core/health.py
+++ b/src/core/health.py
@@ -1,0 +1,207 @@
+"""
+MT5 AI/ML Trading Bot - Enterprise Edition
+src/core/health.py
+Enterprise-grade health check system for production monitoring.
+Author : triqbit
+License: MIT
+"""
+from __future__ import annotations
+
+import logging
+import shutil
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel, Field
+from sqlalchemy import text
+
+from src.core.config import TradingConfig
+from src.core.trade_logger import TradeLogger
+from src.trading.mt5_connector import MT5Connector
+
+logger = logging.getLogger(__name__)
+
+
+class HealthStatus(str, Enum):
+    HEALTHY = "healthy"
+    DEGRADED = "degraded"
+    FAILED = "failed"
+
+
+class ComponentStatus(BaseModel):
+    status: HealthStatus
+    message: str
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    details: Optional[Dict[str, str]] = None
+
+
+class HealthReport(BaseModel):
+    status: HealthStatus
+    overall_message: str
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    components: Dict[str, ComponentStatus]
+
+
+class HealthChecker:
+    """
+    Orchestrates health checks for all system components.
+    """
+
+    def __init__(self, config: TradingConfig) -> None:
+        self.cfg = config
+
+    def get_liveness(self) -> ComponentStatus:
+        """Simple liveness probe - application is running."""
+        return ComponentStatus(
+            status=HealthStatus.HEALTHY,
+            message="Application is responsive",
+        )
+
+    def check_database(self, trade_logger: TradeLogger) -> ComponentStatus:
+        """Verify database connectivity."""
+        try:
+            with trade_logger.engine.connect() as conn:
+                conn.execute(text("SELECT 1"))
+            return ComponentStatus(status=HealthStatus.HEALTHY, message="Database reachable")
+        except Exception as e:
+            logger.error("Health check: Database unreachable: %s", e)
+            return ComponentStatus(
+                status=HealthStatus.FAILED,
+                message=f"Database unreachable: {e!s}",
+            )
+
+    def check_mt5(self, connector: MT5Connector) -> ComponentStatus:
+        """Verify MT5 connection status."""
+        if connector._is_initialized:
+            # Optionally perform a light operation like getting account info
+            try:
+                acc = connector.get_account_info()
+                if acc:
+                    return ComponentStatus(
+                        status=HealthStatus.HEALTHY,
+                        message="MT5 connection alive",
+                        details={"login": str(acc.get("login"))},
+                    )
+                return ComponentStatus(
+                    status=HealthStatus.DEGRADED,
+                    message="MT5 initialized but returned empty account info",
+                )
+            except Exception as e:
+                return ComponentStatus(
+                    status=HealthStatus.FAILED,
+                    message=f"MT5 connectivity check failed: {e!s}",
+                )
+        return ComponentStatus(status=HealthStatus.FAILED, message="MT5 connector not initialized")
+
+    def check_models(self) -> ComponentStatus:
+        """Verify model file existence."""
+        if self.cfg.model_path.exists():
+            return ComponentStatus(
+                status=HealthStatus.HEALTHY,
+                message=f"Model file found at {self.cfg.model_path}",
+            )
+        return ComponentStatus(
+            status=HealthStatus.FAILED,
+            message=f"Model file missing at {self.cfg.model_path}",
+        )
+
+    def check_config(self) -> ComponentStatus:
+        """Validate critical configuration fields."""
+        missing = []
+        if not self.cfg.mt5_password:
+            missing.append("MT5_PASSWORD")
+        if not self.cfg.mt5_server:
+            missing.append("MT5_SERVER")
+
+        if missing:
+            return ComponentStatus(
+                status=HealthStatus.FAILED,
+                message=f"Critical config missing: {', '.join(missing)}",
+            )
+        return ComponentStatus(status=HealthStatus.HEALTHY, message="Config validation passed")
+
+    def check_disk_space(self, min_gb: float = 1.0) -> ComponentStatus:
+        """Verify log directory has sufficient space."""
+        logs_dir = self.cfg.logs_dir
+        if not logs_dir.exists():
+            try:
+                logs_dir.mkdir(parents=True, exist_ok=True)
+            except Exception as e:
+                return ComponentStatus(
+                    status=HealthStatus.FAILED,
+                    message=f"Cannot create logs directory: {e!s}",
+                )
+
+        _, _, free = shutil.disk_usage(logs_dir)
+        free_gb = free / (1024**3)
+
+        if free_gb < min_gb:
+            return ComponentStatus(
+                status=HealthStatus.DEGRADED,
+                message=f"Low disk space: {free_gb:.2f} GB free",
+            )
+        return ComponentStatus(
+            status=HealthStatus.HEALTHY,
+            message=f"Sufficient disk space: {free_gb:.2f} GB free",
+        )
+
+    def get_readiness(
+        self,
+        connector: MT5Connector,
+        trade_logger: TradeLogger,
+    ) -> HealthReport:
+        """Aggregated readiness probe."""
+        components = {
+            "database": self.check_database(trade_logger),
+            "mt5": self.check_mt5(connector),
+            "models": self.check_models(),
+            "config": self.check_config(),
+            "disk": self.check_disk_space(),
+        }
+
+        failed_components = [
+            name for name, res in components.items() if res.status == HealthStatus.FAILED
+        ]
+        degraded_components = [
+            name for name, res in components.items() if res.status == HealthStatus.DEGRADED
+        ]
+
+        if failed_components:
+            status = HealthStatus.FAILED
+            msg = f"Critical health failure in: {', '.join(failed_components)}"
+        elif degraded_components:
+            status = HealthStatus.DEGRADED
+            msg = f"Health degraded in: {', '.join(degraded_components)}"
+        else:
+            status = HealthStatus.HEALTHY
+            msg = "System is ready"
+
+        return HealthReport(
+            status=status,
+            overall_message=msg,
+            components=components,
+        )
+
+
+def startup_health_gate(
+    config: TradingConfig,
+    connector: MT5Connector,
+    trade_logger: TradeLogger,
+) -> None:
+    """
+    Enforce health checks at startup.
+    Raises RuntimeError if critical checks fail.
+    """
+    checker = HealthChecker(config)
+    report = checker.get_readiness(connector, trade_logger)
+
+    if report.status == HealthStatus.FAILED:
+        logger.critical("STARTUP HEALTH GATE FAILED: %s", report.overall_message)
+        for comp, status in report.components.items():
+            if status.status == HealthStatus.FAILED:
+                logger.critical(" - %s: %s", comp.upper(), status.message)
+        raise RuntimeError(f"Startup health check failed: {report.overall_message}")
+
+    logger.info("Startup health gate passed: %s", report.overall_message)

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,199 @@
+"""
+Tests for the health check system.
+"""
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.core.health import ComponentStatus, HealthChecker, HealthStatus, startup_health_gate
+
+
+@pytest.fixture
+def mock_config():
+    config = MagicMock()
+    config.model_path = Path("models/trained/ensemble_latest.pt")
+    config.logs_dir = Path("logs")
+    config.mt5_password = "password"
+    config.mt5_server = "server"
+    return config
+
+
+@pytest.fixture
+def mock_connector():
+    connector = MagicMock()
+    connector._is_initialized = True
+    connector.get_account_info.return_value = {"login": 12345}
+    return connector
+
+
+@pytest.fixture
+def mock_trade_logger():
+    logger = MagicMock()
+    # Mocking sqlalchemy engine and connection
+    mock_conn = MagicMock()
+    logger.engine.connect.return_value.__enter__.return_value = mock_conn
+    return logger
+
+
+def test_health_checker_liveness(mock_config):
+    checker = HealthChecker(mock_config)
+    liveness = checker.get_liveness()
+    assert liveness.status == HealthStatus.HEALTHY
+    assert "Application is responsive" in liveness.message
+
+
+def test_check_database_success(mock_config, mock_trade_logger):
+    checker = HealthChecker(mock_config)
+    status = checker.check_database(mock_trade_logger)
+    assert status.status == HealthStatus.HEALTHY
+    assert "Database reachable" in status.message
+
+
+def test_check_database_failure(mock_config, mock_trade_logger):
+    mock_trade_logger.engine.connect.side_effect = Exception("DB error")
+    checker = HealthChecker(mock_config)
+    status = checker.check_database(mock_trade_logger)
+    assert status.status == HealthStatus.FAILED
+    assert "Database unreachable" in status.message
+
+
+def test_check_mt5_success(mock_config, mock_connector):
+    checker = HealthChecker(mock_config)
+    status = checker.check_mt5(mock_connector)
+    assert status.status == HealthStatus.HEALTHY
+    assert "MT5 connection alive" in status.message
+    assert status.details == {"login": "12345"}
+
+
+def test_check_mt5_not_initialized(mock_config, mock_connector):
+    mock_connector._is_initialized = False
+    checker = HealthChecker(mock_config)
+    status = checker.check_mt5(mock_connector)
+    assert status.status == HealthStatus.FAILED
+    assert "MT5 connector not initialized" in status.message
+
+
+def test_check_models_success(mock_config):
+    with patch.object(Path, "exists", return_value=True):
+        checker = HealthChecker(mock_config)
+        status = checker.check_models()
+        assert status.status == HealthStatus.HEALTHY
+
+
+def test_check_models_failure(mock_config):
+    with patch.object(Path, "exists", return_value=False):
+        checker = HealthChecker(mock_config)
+        status = checker.check_models()
+        assert status.status == HealthStatus.FAILED
+
+
+def test_check_config_success(mock_config):
+    checker = HealthChecker(mock_config)
+    status = checker.check_config()
+    assert status.status == HealthStatus.HEALTHY
+
+
+def test_check_config_failure(mock_config):
+    mock_config.mt5_password = ""
+    checker = HealthChecker(mock_config)
+    status = checker.check_config()
+    assert status.status == HealthStatus.FAILED
+    assert "MT5_PASSWORD" in status.message
+
+
+def test_check_disk_space_success(mock_config):
+    with patch("shutil.disk_usage", return_value=(0, 0, 2 * 1024**3)):
+        with patch.object(Path, "exists", return_value=True):
+            checker = HealthChecker(mock_config)
+            status = checker.check_disk_space()
+            assert status.status == HealthStatus.HEALTHY
+            assert "2.00 GB free" in status.message
+
+
+def test_check_disk_space_degraded(mock_config):
+    with patch("shutil.disk_usage", return_value=(0, 0, 0.5 * 1024**3)):
+        with patch.object(Path, "exists", return_value=True):
+            checker = HealthChecker(mock_config)
+            status = checker.check_disk_space()
+            assert status.status == HealthStatus.DEGRADED
+            assert "0.50 GB free" in status.message
+
+
+def test_get_readiness_overall_healthy(mock_config, mock_connector, mock_trade_logger):
+    checker = HealthChecker(mock_config)
+    with patch.object(
+        checker,
+        "check_database",
+        return_value=ComponentStatus(status=HealthStatus.HEALTHY, message="OK"),
+    ):
+        with patch.object(
+            checker,
+            "check_mt5",
+            return_value=ComponentStatus(status=HealthStatus.HEALTHY, message="OK"),
+        ):
+            with patch.object(
+                checker,
+                "check_models",
+                return_value=ComponentStatus(status=HealthStatus.HEALTHY, message="OK"),
+            ):
+                with patch.object(
+                    checker,
+                    "check_config",
+                    return_value=ComponentStatus(status=HealthStatus.HEALTHY, message="OK"),
+                ):
+                    with patch.object(
+                        checker,
+                        "check_disk_space",
+                        return_value=ComponentStatus(status=HealthStatus.HEALTHY, message="OK"),
+                    ):
+                        report = checker.get_readiness(mock_connector, mock_trade_logger)
+                        assert report.status == HealthStatus.HEALTHY
+
+
+def test_get_readiness_overall_failed(mock_config, mock_connector, mock_trade_logger):
+    checker = HealthChecker(mock_config)
+    with patch.object(
+        checker,
+        "check_database",
+        return_value=ComponentStatus(status=HealthStatus.FAILED, message="Fail"),
+    ):
+        # We need to mock other methods too because get_readiness calls them all
+        with patch.object(
+            checker, "check_mt5", return_value=ComponentStatus(status=HealthStatus.HEALTHY, message="OK")
+        ):
+            with patch.object(
+                checker,
+                "check_models",
+                return_value=ComponentStatus(status=HealthStatus.HEALTHY, message="OK"),
+            ):
+                with patch.object(
+                    checker,
+                    "check_config",
+                    return_value=ComponentStatus(status=HealthStatus.HEALTHY, message="OK"),
+                ):
+                    with patch.object(
+                        checker,
+                        "check_disk_space",
+                        return_value=ComponentStatus(status=HealthStatus.HEALTHY, message="OK"),
+                    ):
+                        report = checker.get_readiness(mock_connector, mock_trade_logger)
+                        assert report.status == HealthStatus.FAILED
+
+
+def test_startup_health_gate_success(mock_config, mock_connector, mock_trade_logger):
+    with patch("src.core.health.HealthChecker.get_readiness") as mock_readiness:
+        mock_readiness.return_value = MagicMock(status=HealthStatus.HEALTHY)
+        # Should not raise
+        startup_health_gate(mock_config, mock_connector, mock_trade_logger)
+
+
+def test_startup_health_gate_failure(mock_config, mock_connector, mock_trade_logger):
+    with patch("src.core.health.HealthChecker.get_readiness") as mock_readiness:
+        mock_readiness.return_value = MagicMock(
+            status=HealthStatus.FAILED,
+            overall_message="Critical health failure",
+            components={"database": MagicMock(status=HealthStatus.FAILED, message="DB down")},
+        )
+        with pytest.raises(RuntimeError, match="Startup health check failed"):
+            startup_health_gate(mock_config, mock_connector, mock_trade_logger)


### PR DESCRIPTION
This change introduces an enterprise-grade health check system to the MT5 AI trading bot. It provides structured, typed health reports and enforces a strict readiness gate at startup to ensure the bot only runs when all critical dependencies and configurations are healthy.

Key components:
- `HealthChecker`: Orchestrates liveness and readiness checks.
- `startup_health_gate`: Enforces readiness during the application initialization.
- Comprehensive test suite for the new health logic.
- Integration into `main.py`.

---
*PR created automatically by Jules for task [17445362571361159494](https://jules.google.com/task/17445362571361159494) started by @andonly1348*