### PR TITLE
Data Retention Policy and Automated Cleanup Script

### DIFF
--- a/docs/DATA_RETENTION_POLICY.md
+++ b/docs/DATA_RETENTION_POLICY.md
@@ -1,0 +1,54 @@
+# Data Retention Policy
+
+## 1. Overview
+This document defines the policies for how long operational data is kept and when it is purged within the MT5 AI/ML Trading Bot system. These policies ensure compliance with regulatory requirements while maintaining system performance and storage efficiency.
+
+## 2. Retention Windows
+
+| Data Type | Retention Period | Action After Period |
+|-----------|------------------|---------------------|
+| Application Logs (`logs/*.log`) | 90 Days | Permanent Deletion |
+| Trade Records (`trades` table) | 7 Years | Permanent Deletion (Regulatory Compliance) |
+| Model Signals (`model_signals` table) | 1 Year | Permanent Deletion |
+| Risk Events (`risk_events` table) | 2 Years | Permanent Deletion |
+| Performance Metrics | 1 Year | Archive to CSV/Parquet, then delete from DB |
+| Backtest Results | 180 Days | Permanent Deletion |
+| Market Data (OHLCV) | 5 Years | Move to Cold Storage |
+
+## 3. Preservation vs. Rotation
+
+### 3.1 Preservation for Auditability
+The following data is preserved to ensure a complete audit trail of trading activity:
+- **Trade Records**: Execution details, tickets, symbols, and PnL.
+- **Audit Logs**: (If implemented) Changes to system configuration or manual overrides.
+- **Risk Events**: Circuit breaker triggers and rejection reasons.
+
+### 3.2 Rotation for Storage Control
+The following data is rotated frequently to prevent disk space exhaustion:
+- **Debug Logs**: Highly verbose logs are kept for a shorter window (90 days).
+- **Model Signals**: High-frequency signal data that did not result in trades.
+- **Temporary Backtest Artifacts**: Large CSVs or plots generated during model training/backtesting.
+
+## 4. Archival Rules
+
+### 4.1 Performance Metrics
+Performance metrics (`performance_metrics` table) are valuable for long-term strategy analysis.
+- Data older than **1 year** will be exported to a structured format (e.g., JSON or Parquet) and stored in the `archives/` directory or cloud storage.
+- After successful archival, records are purged from the live database.
+
+### 4.2 Backtest Results
+Backtest results can consume significant space.
+- Results are kept for **180 days** to allow for comparison between model iterations.
+- Results associated with "Production" model versions may be flagged for indefinite retention until the model is decommissioned.
+
+## 5. Automated Purging Schedule
+An automated cleanup script (`scripts/data_cleanup.py`) is scheduled to run:
+- **Frequency**: Weekly (every Sunday at 00:00 UTC).
+- **Process**:
+    1. Scan `logs/` directory for files older than 90 days.
+    2. Scan database tables for records exceeding their retention window.
+    3. Export/Archive data where required by section 4.
+    4. Perform safe deletion of expired records.
+
+## 6. Compliance and Legal Hold
+In the event of a legal or regulatory inquiry, a "Legal Hold" may be placed on specific datasets, suspending the automated purging for those records until the hold is lifted by an authorized officer.

--- a/scripts/data_cleanup.py
+++ b/scripts/data_cleanup.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""
+Data Retention Cleanup Script
+Purges old logs and database records according to the Data Retention Policy.
+"""
+
+import argparse
+import logging
+import os
+import sys
+import time
+import csv
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from sqlalchemy import create_engine, delete, text
+from sqlalchemy.orm import sessionmaker
+
+# Add src to sys.path to allow imports if running from root
+sys.path.append(os.getcwd())
+
+try:
+    from src.core.config import get_config
+    from src.core.trade_logger import ModelSignal, Trade, RiskEvent, PerformanceMetric
+except ImportError:
+    print("Error: Could not import core modules. Please run this script from the repository root.")
+    sys.exit(1)
+
+# Set up logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s | %(levelname)-8s | %(message)s",
+    handlers=[logging.StreamHandler(sys.stdout)]
+)
+logger = logging.getLogger("data_cleanup")
+
+# Default Retention windows (days) according to docs/DATA_RETENTION_POLICY.md
+RETENTION_CONFIG = {
+    "logs": 90,
+    "trades": 7 * 365,
+    "model_signals": 365,
+    "risk_events": 2 * 365,
+    "performance_metrics": 365,
+    "backtest_results": 180
+}
+
+def cleanup_files(directory: Path, days: int, pattern: str = "*", dry_run: bool = False):
+    """Delete files older than X days in a given directory."""
+    if not directory.exists():
+        logger.warning(f"Directory {directory} does not exist. Skipping cleanup.")
+        return
+
+    cutoff = time.time() - (days * 86400)
+    logger.info(f"Cleaning up {pattern} older than {days} days in {directory}...")
+
+    count = 0
+    for file_path in directory.glob(pattern):
+        if file_path.is_file() and file_path.stat().st_mtime < cutoff:
+            if dry_run:
+                logger.info(f"[DRY RUN] Would delete file: {file_path.name} (Modified: {datetime.fromtimestamp(file_path.stat().st_mtime)})")
+            else:
+                try:
+                    file_path.unlink()
+                    logger.info(f"Deleted file: {file_path.name}")
+                except Exception as e:
+                    logger.error(f"Failed to delete {file_path.name}: {e}")
+            count += 1
+    logger.info(f"Cleaned up {count} files in {directory}.")
+
+def archive_performance_metrics(session, cutoff_date: datetime, archive_dir: Path, dry_run: bool = False):
+    """Archive PerformanceMetric records to CSV before deletion."""
+    records = session.query(PerformanceMetric).filter(PerformanceMetric.created_at < cutoff_date).all()
+    if not records:
+        return 0
+
+    if dry_run:
+        logger.info(f"[DRY RUN] Would archive {len(records)} performance metrics.")
+        return len(records)
+
+    archive_dir.mkdir(exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    filename = archive_dir / f"performance_metrics_archive_{timestamp}.csv"
+
+    logger.info(f"Archiving {len(records)} metrics to {filename}...")
+
+    try:
+        with open(filename, 'w', newline='') as csvfile:
+            # Get columns from the model
+            columns = [column.name for column in PerformanceMetric.__table__.columns]
+            writer = csv.DictWriter(csvfile, fieldnames=columns)
+            writer.writeheader()
+            for record in records:
+                row = {col: getattr(record, col) for col in columns}
+                # Convert datetime objects to string
+                for key, val in row.items():
+                    if isinstance(val, datetime):
+                        row[key] = val.isoformat()
+                writer.writerow(row)
+        return len(records)
+    except Exception as e:
+        logger.error(f"Failed to archive metrics: {e}")
+        raise
+
+def cleanup_db(db_url: str, dry_run: bool = False):
+    """Purge old records from the database based on retention policy."""
+    if db_url.startswith("sqlite") and not db_url.startswith("sqlite:///"):
+        if "://" not in db_url:
+            db_url = f"sqlite:///{db_url}"
+
+    try:
+        engine = create_engine(db_url)
+        Session = sessionmaker(bind=engine)
+    except Exception as e:
+        logger.error(f"Failed to connect to database at {db_url}: {e}")
+        return
+
+    now = datetime.now(timezone.utc)
+
+    model_mapping = {
+        Trade: RETENTION_CONFIG["trades"],
+        ModelSignal: RETENTION_CONFIG["model_signals"],
+        RiskEvent: RETENTION_CONFIG["risk_events"],
+        PerformanceMetric: RETENTION_CONFIG["performance_metrics"]
+    }
+
+    with Session() as session:
+        for model, days in model_mapping.items():
+            cutoff_date = now - timedelta(days=days)
+            date_col = model.created_at
+
+            try:
+                # Special handling for PerformanceMetric archival
+                if model == PerformanceMetric:
+                    archive_dir = Path("archives")
+                    archive_performance_metrics(session, cutoff_date, archive_dir, dry_run=dry_run)
+
+                # Batch deletion for efficiency and safety
+                batch_size = 1000
+                total_deleted = 0
+
+                while True:
+                    # Get IDs to delete in this batch
+                    ids_query = session.query(model.id).filter(date_col < cutoff_date).limit(batch_size).all()
+                    if not ids_query:
+                        break
+
+                    ids_to_delete = [r[0] for r in ids_query]
+
+                    if dry_run:
+                        logger.info(f"[DRY RUN] Would delete {len(ids_to_delete)} records from '{model.__tablename__}' older than {cutoff_date}")
+                        break
+                    else:
+                        session.execute(delete(model).where(model.id.in_(ids_to_delete)))
+                        session.commit()
+                        total_deleted += len(ids_to_delete)
+                        logger.info(f"Deleted {total_deleted} records from '{model.__tablename__}'...")
+
+                if total_deleted == 0 and not dry_run:
+                    logger.info(f"No records to purge for '{model.__tablename__}' (Retention: {days} days).")
+                elif total_deleted > 0:
+                    logger.info(f"Completed purging '{model.__tablename__}'. Total deleted: {total_deleted}")
+
+            except Exception as e:
+                logger.error(f"Error purging table '{model.__tablename__}': {e}")
+                session.rollback()
+
+def main():
+    parser = argparse.ArgumentParser(description="Data Retention Cleanup Script")
+    parser.add_argument("--dry-run", action="store_true", help="Perform a dry run without deleting data")
+    parser.add_argument("--db-url", help="Database URL (overrides config)")
+    parser.add_argument("--log-dir", help="Log directory (overrides config)")
+    args = parser.parse_args()
+
+    # Load config
+    try:
+        cfg = get_config()
+        db_url = args.db_url or cfg.database_url
+        log_dir = Path(args.log_dir or cfg.logs_dir)
+    except Exception as e:
+        logger.error(f"Failed to load configuration: {e}")
+        db_url = args.db_url or "sqlite:///trades.db"
+        log_dir = Path(args.log_dir or "logs")
+
+    logger.info("Starting data retention cleanup...")
+    if args.dry_run:
+        logger.info("Running in DRY RUN mode. No data will be deleted.")
+
+    # 1. Cleanup Logs
+    cleanup_files(log_dir, RETENTION_CONFIG["logs"], pattern="*.log", dry_run=args.dry_run)
+
+    # 2. Cleanup Backtest Results
+    backtest_dirs = [Path("testing/backtest"), Path("data/backtest_results"), Path("backtest")]
+    for bt_dir in backtest_dirs:
+        cleanup_files(bt_dir, RETENTION_CONFIG["backtest_results"], dry_run=args.dry_run)
+
+    # 3. Cleanup Database
+    cleanup_db(db_url, dry_run=args.dry_run)
+
+    logger.info("Cleanup process completed.")
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_data_cleanup.py
+++ b/tests/test_data_cleanup.py
@@ -1,0 +1,134 @@
+import os
+import time
+import csv
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from scripts.data_cleanup import cleanup_files, cleanup_db
+from src.core.trade_logger import Base, Trade, ModelSignal, RiskEvent, PerformanceMetric
+
+@pytest.fixture
+def temp_dirs(tmp_path):
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+
+    # Create an old log file
+    old_log = log_dir / "old.log"
+    old_log.write_text("old content")
+
+    # Set modification time to 100 days ago
+    old_time = time.time() - (100 * 86400)
+    os.utime(old_log, (old_time, old_time))
+
+    # Create a new log file
+    new_log = log_dir / "new.log"
+    new_log.write_text("new content")
+
+    # Backtest dir
+    bt_dir = tmp_path / "backtest"
+    bt_dir.mkdir()
+    old_bt = bt_dir / "old_result.csv"
+    old_bt.write_text("old bt")
+    bt_time = time.time() - (200 * 86400)
+    os.utime(old_bt, (bt_time, bt_time))
+
+    return {"logs": log_dir, "backtest": bt_dir}
+
+@pytest.fixture
+def temp_db(tmp_path):
+    db_path = tmp_path / "test_trades.db"
+    db_url = f"sqlite:///{db_path}"
+    engine = create_engine(db_url)
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+
+    with Session() as session:
+        # Create an old trade (should be kept because retention is 7 years)
+        old_trade = Trade(
+            ticket=1001,
+            symbol="XAUUSD",
+            direction=1,
+            entry_price=2000.0,
+            lot_size=0.1,
+            created_at=datetime.now(timezone.utc) - timedelta(days=365 * 2)
+        )
+        # Create a VERY old trade (should be deleted)
+        very_old_trade = Trade(
+            ticket=1000,
+            symbol="XAUUSD",
+            direction=1,
+            entry_price=1900.0,
+            lot_size=0.1,
+            created_at=datetime.now(timezone.utc) - timedelta(days=365 * 8)
+        )
+
+        # Create an old signal (should be deleted because retention is 1 year)
+        old_signal = ModelSignal(
+            symbol="XAUUSD",
+            direction=1,
+            entry_price=2010.0,
+            created_at=datetime.now(timezone.utc) - timedelta(days=400)
+        )
+
+        # Create an old performance metric (should be archived and deleted)
+        old_metric = PerformanceMetric(
+            sharpe_ratio=2.5,
+            profit_factor=1.8,
+            created_at=datetime.now(timezone.utc) - timedelta(days=400)
+        )
+
+        session.add_all([old_trade, very_old_trade, old_signal, old_metric])
+        session.commit()
+
+    return db_url
+
+def test_cleanup_files(temp_dirs):
+    log_dir = temp_dirs["logs"]
+    # Run cleanup
+    cleanup_files(log_dir, days=90, pattern="*.log")
+
+    assert not (log_dir / "old.log").exists()
+    assert (log_dir / "new.log").exists()
+
+    bt_dir = temp_dirs["backtest"]
+    cleanup_files(bt_dir, days=180)
+    assert not (bt_dir / "old_result.csv").exists()
+
+def test_cleanup_db_and_archival(temp_db, tmp_path):
+    # Change to tmp_path to control where 'archives' is created
+    os.chdir(tmp_path)
+
+    # Run cleanup
+    cleanup_db(temp_db)
+
+    engine = create_engine(temp_db)
+    Session = sessionmaker(bind=engine)
+    with Session() as session:
+        # Check Trades
+        trades = session.query(Trade).all()
+        assert len(trades) == 1
+        assert trades[0].ticket == 1001
+
+        # Check Signals
+        signals = session.query(ModelSignal).all()
+        assert len(signals) == 0
+
+        # Check Metrics
+        metrics = session.query(PerformanceMetric).all()
+        assert len(metrics) == 0
+
+    # Verify archival
+    archive_dir = tmp_path / "archives"
+    assert archive_dir.exists()
+    archives = list(archive_dir.glob("performance_metrics_archive_*.csv"))
+    assert len(archives) == 1
+
+    with open(archives[0], newline='') as csvfile:
+        reader = csv.DictReader(csvfile)
+        rows = list(reader)
+        assert len(rows) == 1
+        assert float(rows[0]['sharpe_ratio']) == 2.5


### PR DESCRIPTION
This PR introduces a formal data retention policy and an automated cleanup utility for the MT5 AI/ML Trading Bot.

### Key Changes:
1.  **Retention Policy (`docs/DATA_RETENTION_POLICY.md`)**:
    *   Defines clear windows: 90 days for logs, 7 years for trade records (compliance), 1 year for model signals, and 180 days for backtest results.
    *   Distinguishes between data preserved for auditability and data rotated for storage efficiency.
2.  **Cleanup Script (`scripts/data_cleanup.py`)**:
    *   Enforces the retention policy on both the filesystem (logs, backtests) and the database (SQLAlchemy models).
    *   **Archival Logic**: Automatically exports `PerformanceMetric` records to CSV in the `archives/` directory before purging them from the live database.
    *   **Operational Safety**: Includes a `--dry-run` flag for previewing deletions and uses batched deletions (1000 records per transaction) to prevent database locks and performance degradation.
3.  **Verification & Testing**:
    *   Added `tests/test_data_cleanup.py` covering file cleanup, database purging, and archival integrity.
    *   Verified against the enterprise standards and code review feedback.

This ensures the system remains compliant with regulatory requirements while preventing disk exhaustion in production environments.

---
*PR created automatically by Jules for task [4744539015408409790](https://jules.google.com/task/4744539015408409790) started by @andonly1348*