### PR TITLE
🛡️ Jules02: Risk control and drift monitoring — Ensemble dissent and operational limits

### DIFF
--- a/RISK_LIMITS.md
+++ b/RISK_LIMITS.md
@@ -44,10 +44,10 @@ Defines immutable hard limits and automatic circuit breakers to protect capital,
 - **Rationale**: Prevents overconfidence and excessive risk
 
 ### 2.3 Daily Trade Limits
-- **Max Trades**: 20 trades per day
+- **Max Trades**: 20 trades per day (Enforced in `RiskManager`)
 - **Max Winning Streaks**: Alert after 5 consecutive wins
-- **Max Losing Streaks**: Halt trading after 3 consecutive losses
-- **Consecutive Losses**: Reset at daily close (00:00 UTC)
+- **Max Losing Streaks**: Halt trading after 3 consecutive losses (Enforced in `RiskManager`)
+- **Consecutive Losses**: Reset at daily close (00:00 UTC) or on first win
 
 ## 3. Weekly/Monthly Limits
 
@@ -80,7 +80,7 @@ Defines immutable hard limits and automatic circuit breakers to protect capital,
 
 ### 4.3 Prediction Diversity
 - **Ensemble Diversity**: Require 3+ models agreeing
-- **Model Dissent**: If 2 models strongly disagree, skip trade
+- **Model Dissent**: If 2 models strongly disagree (one BUY, one SELL), skip trade (Enforced in `RiskManager`)
 - **Consensus Threshold**: Need 60%+ agreement across ensemble
 - **Veto Power**: Any model with <40% confidence forces skip
 

--- a/main.py
+++ b/main.py
@@ -72,7 +72,7 @@ def run_live(
             # 2. Build observation vector
             obs = df[["open", "high", "low", "close", "tick_volume"]].values[-1]
             # 3. Get ensemble prediction
-            direction, confidence, _per_algo = model.predict(obs)
+            direction, confidence, per_algo = model.predict(obs)
             log.debug("Signal | dir=%d conf=%.3f", direction, confidence)
 
             signal_id = None
@@ -111,6 +111,7 @@ def run_live(
                 lot_size=lot_size,
                 algorithm=cfg.algorithm,
                 confidence=confidence,
+                model_votes={k: int(v) for k, v in per_algo.items()},
             )
             # 5. Risk approval gate
             if risk.approve(signal, signal_id=signal_id):
@@ -207,9 +208,10 @@ def main() -> int:
     trade_logger = TradeLogger(
         db_url=cfg.database_url if "sqlite" in cfg.database_url else "sqlite:///trades.db"
     )
-    risk = RiskManager(cfg, account_balance=balance, logger_db=trade_logger)
     monitor = Monitor(cfg)
-    risk = RiskManager(cfg, account_balance=balance, monitor=monitor)
+    risk = RiskManager(
+        cfg, account_balance=balance, logger_db=trade_logger, monitor=monitor
+    )
     model = EnsembleModel(device="cpu")
     ppo_path = args.model_dir / "ppo_xauusd.zip"
     lstm_path = args.model_dir / "lstm_xauusd.pt"
@@ -219,8 +221,14 @@ def main() -> int:
         model.load_lstm(lstm_path)
     try:
         if cfg.mode in ("demo", "live"):
-            run_live(cfg, connector, risk, model, trade_logger=trade_logger)
-            run_live(cfg, connector, risk, model, monitor)
+            run_live(
+                cfg,
+                connector,
+                risk,
+                model,
+                trade_logger=trade_logger,
+                monitor=monitor,
+            )
         elif cfg.mode == "backtest":
             log.info("Backtest mode - see scripts/backtest.py")
     finally:

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -48,6 +48,8 @@ class TradingConfig(BaseSettings):
     max_positions: int = Field(default=3, ge=1, le=10)
     risk_per_trade: float = Field(default=0.01, ge=0.001, le=0.05)
     max_daily_loss: float = Field(default=0.05, ge=0.01, le=0.20)
+    max_daily_trades: int = Field(default=20, ge=1, le=100)
+    max_consecutive_losses: int = Field(default=3, ge=1, le=10)
 
     # ── Model ──────────────────────────────────────────────────────────────────
     algorithm: Literal["ppo", "dreamer", "lstm", "ensemble"] = Field(default="ensemble")

--- a/src/models/ensemble.py
+++ b/src/models/ensemble.py
@@ -148,7 +148,7 @@ class EnsembleModel:
         confidence = float(blended[action_idx])
         direction_map = {0: 1, 1: -1, 2: 0}
         direction = direction_map[action_idx]
-        per_algo = {k: float(np.argmax(votes[k])) for k in votes}
+        per_algo = {k: float(direction_map[int(np.argmax(votes[k]))]) for k in votes}
         logger.debug(
             "Ensemble | dir=%d conf=%.3f votes=%s",
             direction,

--- a/src/trading/risk_manager.py
+++ b/src/trading/risk_manager.py
@@ -47,6 +47,7 @@ class TradeSignal:
     lot_size: float
     algorithm: str
     confidence: float  # 0.0 - 1.0
+    model_votes: Dict[str, int] = field(default_factory=dict)
     timestamp: datetime = field(default_factory=datetime.utcnow)
 
 
@@ -57,6 +58,7 @@ class DailyStats:
     date: date = field(default_factory=date.today)
     realised_pnl: float = 0.0
     trade_count: int = 0
+    consecutive_losses: int = 0
     peak_equity: float = 0.0
 
 
@@ -95,10 +97,16 @@ class RiskManager:
             rejection_reason = "Daily loss limit reached"
         elif not self._check_max_positions():
             rejection_reason = "Max positions reached"
+        elif not self._check_daily_trade_limit():
+            rejection_reason = "Daily trade limit reached"
+        elif not self._check_consecutive_losses():
+            rejection_reason = "Max consecutive losses reached"
         elif not self._check_symbol_allocation(signal.symbol):
             rejection_reason = f"Symbol {signal.symbol} not in portfolio"
         elif not self._check_minimum_confidence(signal.confidence):
             rejection_reason = f"Confidence {signal.confidence:.2f} too low"
+        elif not self._check_ensemble_dissent(signal.model_votes):
+            rejection_reason = "Ensemble models in direct opposition"
         elif not self._check_risk_reward(signal):
             rejection_reason = "Risk-Reward ratio too low"
 
@@ -155,9 +163,13 @@ class RiskManager:
             self.daily.peak_equity = current_equity
 
     def record_pnl(self, pnl: float) -> None:
-        """Accumulate intraday realised PnL."""
+        """Accumulate intraday realised PnL and track consecutive losses."""
         self.daily.realised_pnl += pnl
         self.daily.trade_count += 1
+        if pnl < 0:
+            self.daily.consecutive_losses += 1
+        else:
+            self.daily.consecutive_losses = 0
 
     def reset_daily(self) -> None:
         """Must be called at the start of each trading day."""
@@ -201,6 +213,18 @@ class RiskManager:
             return False
         return True
 
+    def _check_daily_trade_limit(self) -> bool:
+        if self.daily.trade_count >= self.cfg.max_daily_trades:
+            logger.warning("Daily trade limit hit: %d", self.cfg.max_daily_trades)
+            return False
+        return True
+
+    def _check_consecutive_losses(self) -> bool:
+        if self.daily.consecutive_losses >= self.cfg.max_consecutive_losses:
+            logger.warning("Max consecutive losses hit: %d", self.cfg.max_consecutive_losses)
+            return False
+        return True
+
     def _check_symbol_allocation(self, symbol: str) -> bool:
         """Block trading on symbols not in the All-Weather portfolio."""
         if symbol not in ALLOCATION_WEIGHTS:
@@ -215,6 +239,19 @@ class RiskManager:
             logger.debug(
                 "Confidence %.2f below threshold %.2f", confidence, threshold
             )
+            return False
+        return True
+
+    def _check_ensemble_dissent(self, model_votes: Dict[str, int]) -> bool:
+        """
+        Detect model instability.
+        Reject if any two models are in direct opposition (one BUY, one SELL).
+        """
+        if not model_votes:
+            return True
+        votes = list(model_votes.values())
+        if 1 in votes and -1 in votes:
+            logger.warning("Ensemble DISSENT: models in direct opposition %s", model_votes)
             return False
         return True
 

--- a/tests/test_risk_manager_hardening.py
+++ b/tests/test_risk_manager_hardening.py
@@ -1,0 +1,97 @@
+import pytest
+from datetime import datetime
+from src.trading.risk_manager import RiskManager, TradeSignal, DailyStats
+from src.core.config import TradingConfig
+
+@pytest.fixture
+def config():
+    return TradingConfig(
+        mt5_password="test",
+        mt5_server="test",
+        max_daily_trades=10,
+        max_consecutive_losses=2,
+        risk_per_trade=0.01  # Explicitly set to a safe value
+    )
+
+@pytest.fixture
+def risk_manager(config):
+    return RiskManager(config, account_balance=10000.0)
+
+def test_ensemble_dissent_rejection(risk_manager):
+    signal = TradeSignal(
+        symbol="XAUUSD",
+        direction=1,
+        entry_price=2000.0,
+        stop_loss=1990.0,
+        take_profit=2020.0,
+        lot_size=0.1,
+        algorithm="ensemble",
+        confidence=0.7,
+        model_votes={"ppo": 1, "lstm": -1}  # Direct opposition
+    )
+    assert risk_manager.approve(signal) is False
+
+def test_ensemble_no_dissent_approval(risk_manager):
+    signal = TradeSignal(
+        symbol="XAUUSD",
+        direction=1,
+        entry_price=2000.0,
+        stop_loss=1990.0,
+        take_profit=2020.0,
+        lot_size=0.1,
+        algorithm="ensemble",
+        confidence=0.7,
+        model_votes={"ppo": 1, "lstm": 0}  # No opposition
+    )
+    assert risk_manager.approve(signal) is True
+
+def test_daily_trade_limit(risk_manager):
+    risk_manager.daily.trade_count = 10
+    signal = TradeSignal(
+        symbol="XAUUSD",
+        direction=1,
+        entry_price=2000.0,
+        stop_loss=1990.0,
+        take_profit=2020.0,
+        lot_size=0.1,
+        algorithm="ensemble",
+        confidence=0.7,
+        model_votes={"ppo": 1}
+    )
+    assert risk_manager.approve(signal) is False
+
+def test_consecutive_losses_halt(risk_manager):
+    risk_manager.record_pnl(-100.0)
+    risk_manager.record_pnl(-50.0)
+    assert risk_manager.daily.consecutive_losses == 2
+
+    signal = TradeSignal(
+        symbol="XAUUSD",
+        direction=1,
+        entry_price=2000.0,
+        stop_loss=1990.0,
+        take_profit=2020.0,
+        lot_size=0.1,
+        algorithm="ensemble",
+        confidence=0.7,
+        model_votes={"ppo": 1}
+    )
+    assert risk_manager.approve(signal) is False
+
+def test_consecutive_losses_reset_on_win(risk_manager):
+    risk_manager.record_pnl(-100.0)
+    risk_manager.record_pnl(50.0)
+    assert risk_manager.daily.consecutive_losses == 0
+
+    signal = TradeSignal(
+        symbol="XAUUSD",
+        direction=1,
+        entry_price=2000.0,
+        stop_loss=1990.0,
+        take_profit=2020.0,
+        lot_size=0.1,
+        algorithm="ensemble",
+        confidence=0.7,
+        model_votes={"ppo": 1}
+    )
+    assert risk_manager.approve(signal) is True


### PR DESCRIPTION
### 🛡️ Jules02: Risk control and drift monitoring — Ensemble dissent and operational limits

**1. Risk or Quality Gap Found:**
- **Model Instability:** The ensemble could trigger trades even when sub-models were in direct opposition (e.g., one BUY and one SELL), indicating high uncertainty or regime drift.
- **Over-trading Risk:** There was no hard limit on the number of trades executed per day, leaving the system vulnerable to "prediction storms."
- **Loss Streak Protection:** No automated "circuit breaker" for consecutive losses existed to prevent tilt or continued trading during poor model performance.
- **Architectural Bugs:** A critical initialization bug in `main.py` caused the `RiskManager` to be instantiated twice, effectively disabling either the logger or the monitor and breaking the `run_live` execution loop's safety gating.

**2. Changes Made:**
- **`main.py` Hardening:** Consolidated `RiskManager` initialization and fixed the `run_live` call structure.
- **Inference Mapping:** Modified `EnsembleModel.predict` to return explicit trading directions (+1, -1, 0) for each sub-model.
- **Ensemble Dissent Guardrail:** Added `_check_ensemble_dissent` to `RiskManager.approve` to reject trades if models are in direct opposition.
- **Operational Limits:** Added and enforced `max_daily_trades` and `max_consecutive_losses` (halt after 3 losses by default) in `TradingConfig` and `RiskManager`.
- **State Tracking:** Updated `DailyStats` and `record_pnl` to track and reset consecutive loss counts.

**3. Validation Performed:**
- Created a new test suite `tests/test_risk_manager_hardening.py` covering all new safety logic.
- Verified that all existing unit tests pass.
- Performed a code review confirming that the changes are conservative, defensive, and correctly implemented.

**4. Out of Scope:**
- Altering the core Kelly Criterion sizing logic (only added hard stop-gates).
- Implementing full model retraining on drift (only detection and blocking).

**5. Follow-up Recommendation:**
- Implement model drift detection based on rolling average confidence degradation over several days.

---
*PR created automatically by Jules for task [1712677023717371876](https://jules.google.com/task/1712677023717371876) started by @xnessom*