### PR TITLE
Implement 6-Layer Execution Filter and Tests

### DIFF
--- a/src/trading/__init__.py
+++ b/src/trading/__init__.py
@@ -2,7 +2,15 @@
 
 from __future__ import annotations
 
+from src.trading.execution_filter import ExecutionDecision, ExecutionFilter
 from src.trading.mt5_connector import MT5Connector
 from src.trading.risk_manager import DailyStats, RiskManager, TradeSignal
 
-__all__ = ["DailyStats", "MT5Connector", "RiskManager", "TradeSignal"]
+__all__ = [
+    "DailyStats",
+    "ExecutionDecision",
+    "ExecutionFilter",
+    "MT5Connector",
+    "RiskManager",
+    "TradeSignal",
+]

--- a/src/trading/execution_filter.py
+++ b/src/trading/execution_filter.py
@@ -1,0 +1,159 @@
+"""
+MT5 AI/ML Trading Bot - Enterprise Edition
+src/trading/execution_filter.py
+Institutional 6-layer execution filter cascade.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import time, timezone
+from typing import Optional
+
+import pandas as pd
+
+from src.trading.risk_manager import TradeSignal
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ExecutionDecision:
+    """Outcome of the execution filter cascade."""
+
+    signal: TradeSignal
+    confidence_score: float
+    blocked_by: Optional[str] = None
+
+    @property
+    def is_allowed(self) -> bool:
+        """Returns True if no filter blocked the signal."""
+        return self.blocked_by is None
+
+
+class ExecutionFilter:
+    """
+    Institutional 6-layer execution filter.
+    Validates signals against volatility, trend, momentum, time, and risk constraints.
+    """
+
+    def validate(
+        self,
+        signal: TradeSignal,
+        data: pd.DataFrame,
+        current_drawdown: float
+    ) -> ExecutionDecision:
+        """
+        Run the full 6-layer filter cascade.
+        Args:
+            signal: The TradeSignal to validate.
+            data: DataFrame containing OHLCV and indicators (ATR, EMA_20, EMA_50, EMA_200, RSI).
+            current_drawdown: Current account drawdown (0.0 to 1.0).
+        Returns:
+            ExecutionDecision object.
+        """
+        # 1. ATR Volatility Threshold
+        if not self._check_atr_volatility(data):
+            return ExecutionDecision(signal, signal.confidence * 0.8, "ATR_VOLATILITY")
+
+        # 2. Trend Angle Confirmation
+        if not self._check_trend_angle(signal, data):
+            return ExecutionDecision(signal, signal.confidence * 0.7, "TREND_ANGLE")
+
+        # 3. EMA Sequence Check
+        if not self._check_ema_sequence(signal, data):
+            return ExecutionDecision(signal, signal.confidence * 0.6, "EMA_SEQUENCE")
+
+        # 4. Momentum Filter
+        if not self._check_momentum(signal, data):
+            return ExecutionDecision(signal, signal.confidence * 0.5, "MOMENTUM")
+
+        # 5. Session/Time Filter
+        if not self._check_session(signal):
+            return ExecutionDecision(signal, signal.confidence * 0.9, "SESSION_CLOSED")
+
+        # 6. Drawdown Circuit Breaker
+        if not self._check_drawdown(current_drawdown):
+            return ExecutionDecision(signal, 0.0, "DRAWDOWN_LIMIT")
+
+        return ExecutionDecision(signal, signal.confidence)
+
+    def _check_atr_volatility(self, data: pd.DataFrame, window: int = 30) -> bool:
+        """ATR < 3x historical average to avoid extreme volatility spikes."""
+        if "ATR" not in data.columns:
+            logger.warning("ATR column missing from data")
+            return True
+
+        current_atr = data["ATR"].iloc[-1]
+        atr_sma = data["ATR"].rolling(window=window).mean().iloc[-1]
+
+        if pd.isna(atr_sma):
+            return True # Not enough data to block
+
+        return current_atr < (3 * atr_sma)
+
+    def _check_trend_angle(self, signal: TradeSignal, data: pd.DataFrame) -> bool:
+        """EMA_50 slope must align with trade direction."""
+        if "EMA_50" not in data.columns or len(data) < 2:
+            return True
+
+        current_ema50 = data["EMA_50"].iloc[-1]
+        prev_ema50 = data["EMA_50"].iloc[-2]
+
+        if signal.direction > 0: # Buy
+            return current_ema50 > prev_ema50
+        elif signal.direction < 0: # Sell
+            return current_ema50 < prev_ema50
+
+        return False
+
+    def _check_ema_sequence(self, signal: TradeSignal, data: pd.DataFrame) -> bool:
+        """EMA 20 > 50 > 200 for Buy, reversed for Sell."""
+        cols = ["EMA_20", "EMA_50", "EMA_200"]
+        if not all(c in data.columns for c in cols):
+            return True
+
+        ema20 = data["EMA_20"].iloc[-1]
+        ema50 = data["EMA_50"].iloc[-1]
+        ema200 = data["EMA_200"].iloc[-1]
+
+        if signal.direction > 0: # Buy
+            return ema20 > ema50 > ema200
+        elif signal.direction < 0: # Sell
+            return ema20 < ema50 < ema200
+
+        return False
+
+    def _check_momentum(self, signal: TradeSignal, data: pd.DataFrame) -> bool:
+        """RSI > 50 for Buy, < 50 for Sell."""
+        if "RSI" not in data.columns:
+            return True
+
+        rsi = data["RSI"].iloc[-1]
+
+        if signal.direction > 0: # Buy
+            return rsi > 50
+        elif signal.direction < 0: # Sell
+            return rsi < 50
+
+        return False
+
+    def _check_session(self, signal: TradeSignal) -> bool:
+        """Trade only between 08:00 and 21:00 GMT."""
+        # Convert timestamp to GMT if it's not already
+        ts = signal.timestamp
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        else:
+            ts = ts.astimezone(timezone.utc)
+
+        current_time = ts.time()
+        start_time = time(8, 0)
+        end_time = time(21, 0)
+
+        return start_time <= current_time <= end_time
+
+    def _check_drawdown(self, current_drawdown: float, limit: float = 0.15) -> bool:
+        """Block if account drawdown exceeds limit."""
+        return current_drawdown < limit

--- a/tests/test_execution_filter.py
+++ b/tests/test_execution_filter.py
@@ -1,0 +1,130 @@
+"""
+MT5 AI/ML Trading Bot - Enterprise Edition
+tests/test_execution_filter.py
+Unit tests for institutional execution filter cascade.
+"""
+
+from datetime import datetime, time, timezone
+
+import pandas as pd
+import pytest
+
+from src.trading.execution_filter import ExecutionFilter
+from src.trading.risk_manager import TradeSignal
+
+
+@pytest.fixture
+def execution_filter():
+    return ExecutionFilter()
+
+
+@pytest.fixture
+def base_signal():
+    return TradeSignal(
+        symbol="XAUUSD",
+        direction=1,
+        entry_price=2000.0,
+        stop_loss=1990.0,
+        take_profit=2020.0,
+        lot_size=0.1,
+        algorithm="test",
+        confidence=0.8,
+        timestamp=datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+    )
+
+
+@pytest.fixture
+def mock_market_data():
+    data = {
+        "ATR": [1.0] * 31,
+        "EMA_20": [2000.0] * 31,
+        "EMA_50": [1990.0] * 31,
+        "EMA_200": [1950.0] * 31,
+        "RSI": [55.0] * 31,
+    }
+    # Adjust last two for trend angle
+    data["EMA_50"][29] = 1989.0
+    data["EMA_50"][30] = 1990.0
+    return pd.DataFrame(data)
+
+
+def test_atr_volatility_filter(execution_filter, base_signal, mock_market_data):
+    # Pass case
+    decision = execution_filter.validate(base_signal, mock_market_data, 0.05)
+    assert decision.is_allowed
+
+    # Block case: ATR spike
+    mock_market_data.loc[30, "ATR"] = 4.0 # > 3 * 1.0
+    decision = execution_filter.validate(base_signal, mock_market_data, 0.05)
+    assert not decision.is_allowed
+    assert decision.blocked_by == "ATR_VOLATILITY"
+
+
+def test_trend_angle_filter(execution_filter, base_signal, mock_market_data):
+    # Pass case (Buy direction, EMA_50 rising)
+    decision = execution_filter.validate(base_signal, mock_market_data, 0.05)
+    assert decision.is_allowed
+
+    # Block case: Buy direction, EMA_50 falling
+    mock_market_data.loc[30, "EMA_50"] = 1988.0 # < 1989.0
+    decision = execution_filter.validate(base_signal, mock_market_data, 0.05)
+    assert not decision.is_allowed
+    assert decision.blocked_by == "TREND_ANGLE"
+
+    # Pass case (Sell direction, EMA_50 falling)
+    base_signal.direction = -1
+    # Adjust EMAs for bearish sequence to pass EMA_SEQUENCE filter
+    mock_market_data.loc[30, "EMA_20"] = 1900.0
+    mock_market_data.loc[30, "EMA_50"] = 1910.0
+    mock_market_data.loc[29, "EMA_50"] = 1911.0
+    mock_market_data.loc[30, "EMA_200"] = 1950.0
+    mock_market_data.loc[30, "RSI"] = 45.0 # Pass MOMENTUM for sell
+    decision = execution_filter.validate(base_signal, mock_market_data, 0.05)
+    assert decision.is_allowed
+
+
+def test_ema_sequence_filter(execution_filter, base_signal, mock_market_data):
+    # Pass case (Buy: 20 > 50 > 200)
+    decision = execution_filter.validate(base_signal, mock_market_data, 0.05)
+    assert decision.is_allowed
+
+    # Block case (Buy: out of sequence)
+    mock_market_data.loc[30, "EMA_20"] = 1900.0 # < EMA_50 (1990)
+    decision = execution_filter.validate(base_signal, mock_market_data, 0.05)
+    assert not decision.is_allowed
+    assert decision.blocked_by == "EMA_SEQUENCE"
+
+
+def test_momentum_filter(execution_filter, base_signal, mock_market_data):
+    # Pass case (Buy: RSI > 50)
+    decision = execution_filter.validate(base_signal, mock_market_data, 0.05)
+    assert decision.is_allowed
+
+    # Block case (Buy: RSI < 50)
+    mock_market_data.loc[30, "RSI"] = 45.0
+    decision = execution_filter.validate(base_signal, mock_market_data, 0.05)
+    assert not decision.is_allowed
+    assert decision.blocked_by == "MOMENTUM"
+
+
+def test_session_filter(execution_filter, base_signal, mock_market_data):
+    # Pass case (12:00 GMT)
+    decision = execution_filter.validate(base_signal, mock_market_data, 0.05)
+    assert decision.is_allowed
+
+    # Block case (05:00 GMT)
+    base_signal.timestamp = datetime(2024, 1, 1, 5, 0, tzinfo=timezone.utc)
+    decision = execution_filter.validate(base_signal, mock_market_data, 0.05)
+    assert not decision.is_allowed
+    assert decision.blocked_by == "SESSION_CLOSED"
+
+
+def test_drawdown_filter(execution_filter, base_signal, mock_market_data):
+    # Pass case (5% drawdown)
+    decision = execution_filter.validate(base_signal, mock_market_data, 0.05)
+    assert decision.is_allowed
+
+    # Block case (20% drawdown)
+    decision = execution_filter.validate(base_signal, mock_market_data, 0.20)
+    assert not decision.is_allowed
+    assert decision.blocked_by == "DRAWDOWN_LIMIT"


### PR DESCRIPTION
I have implemented the institutional 6-layer execution filter as described in the README.md. The filter cascade validates signals against ATR volatility, Trend Angle (EMA 50 slope), EMA Sequence (20/50/200), RSI Momentum, Trading Session (08:00-21:00 GMT), and account drawdown limits.

Key changes:
- Created `src/trading/execution_filter.py` containing `ExecutionFilter` and `ExecutionDecision`.
- Updated `src/trading/__init__.py` to expose the new functionality.
- Added a full suite of unit tests in `tests/test_execution_filter.py` covering all filter layers and edge cases.
- Verified that all 18 tests (new and existing) pass successfully.

---
*PR created automatically by Jules for task [2244638224745496908](https://jules.google.com/task/2244638224745496908) started by @triqbit*