### PR TITLE
🎯 Jules05: Merge queue update [2026-04-28]

### DIFF
--- a/docs/integration/merge_queue.md
+++ b/docs/integration/merge_queue.md
@@ -1,0 +1,42 @@
+# 🎯 Jules05: Deterministic Merge Queue [2026-04-28]
+
+This document serves as the authoritative source of truth for the integration state and merge priorities of the repository, managed by Jules05.
+
+## 📊 Summary State
+- **Merge-Ready**: 5
+- **Fix-Required**: 0
+- **Blocked**: 0
+- **Risky (Escalated)**: 2
+- **Superseded**: 0
+
+---
+
+## 🚀 Priority Merge Queue
+
+| Order | Branch | Classification | Rationale | Next Action |
+| :--- | :--- | :--- | :--- | :--- |
+| 1 | `origin/fix/jules05-harmonization-6949952969784913660` | merge-ready | Resolves critical cross-agent conflicts in `main.py` and `MT5Connector`. Essential for system coherence. | Merge immediately. |
+| 2 | `origin/dependency-management-and-security-16960673108976038504` | merge-ready | Hardens security and standardizes dependencies. High hygiene value. | Merge after Order #1. |
+| 3 | `origin/add-operational-runbooks-1241299720848641225` | merge-ready | High-value operational documentation with zero code risk. | Merge. |
+| 4 | `origin/atlas/health-monitoring-gate-16243718335848234220` | merge-ready | Implements enterprise-grade startup health checks. Enhances reliability. | Review `main.py` integration then merge. |
+| 5 | `origin/bolt/optimize-gym-env-observations-16744521746686060435` | merge-ready | Performance optimization for RL observation generation. Low risk, high value. | Merge. |
+
+---
+
+## ⚠️ Escalation List (Requires Human Sign-off)
+
+The following changes touch high-risk areas (trading logic, risk limits) and require manual review per the Jules05 Escalation Policy.
+
+| Branch | Reason for Escalation | Impact Area |
+| :--- | :--- | :--- |
+| `origin/advanced-risk-management-9398696029163028749` | Implements new advanced risk rules and modifies `risk_manager.py`. | Risk Engine |
+| `origin/atlas-production-ready-logic-3183940976416666717` | Modifies entrypoint (`main.py`) and risk validation logic. | Execution Logic |
+
+---
+
+## 📅 Stale / Low-Priority Work
+- None identified in current priority sweep.
+
+---
+
+*Last Updated: 2026-04-28 by Jules05*


### PR DESCRIPTION
Establish the deterministic merge queue for April 28, 2026. This PR classifies pending branches from Jules01-04, prioritizes them based on system value and safety, and escalates high-risk changes (trading logic/risk limits) for human review.

---
*PR created automatically by Jules for task [9009949916187017520](https://jules.google.com/task/9009949916187017520) started by @yxynoty*