### PR TITLE
DX: daily merge-readiness checklist [2026-05-04]

### DIFF
--- a/docs/status/MERGE_READY_CHECKLIST.md
+++ b/docs/status/MERGE_READY_CHECKLIST.md
@@ -3,27 +3,30 @@
 > [!IMPORTANT]
 > **Critical Repository State Notice:** The `main` branch is currently operating under a history-grafting model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules.
 
-Generated on: 2026-05-04 13:42:19 UTC
+Generated on: 2026-05-04 17:50:00 UTC
 
-This checklist identifies top promising PRs for immediate review.
+This checklist identifies top promising PRs for immediate review to assist Jules05 and human reviewers.
 
 ## 1. PR #597: chore(deps)(deps): bump ruff from 0.4.3 to 0.15.12
-- **Status**: Ready for detailed review
-- **Risk**: Safe Surface
-- **Why**: Improved safe surface candidate
-- **Verification**: See PR for CI status.
+- **Scope**: Upgrades Ruff linter/formatter to the latest version to improve linting accuracy and performance.
+- **Domains**: Infra, Developer Experience (Linting)
+- **CI Status**: Pending (Safe surface dependency bump)
+- **Missing Items**: None
+- **Recommendation**: Ready for detailed review
 
 ## 2. PR #589: chore(deps)(deps): bump joblib from 1.4.2 to 1.5.3
-- **Status**: Ready for detailed review
-- **Risk**: Safe Surface
-- **Why**: Improved safe surface candidate
-- **Verification**: See PR for CI status.
+- **Scope**: Upgrades Joblib for improved serialization and concurrency handling.
+- **Domains**: Infra, Core Dependencies
+- **CI Status**: Pending (Safe surface dependency bump)
+- **Missing Items**: None
+- **Recommendation**: Ready for detailed review
 
-## 3. PR #491: 🧹 Jules05: Technical debt cleanup — architectural harmonization
-- **Status**: Ready for detailed review
-- **Risk**: Safe Surface
-- **Why**: Improved safe surface candidate
-- **Verification**: See PR for CI status.
+## 3. PR #539: Institutional Feature Engineering Pipeline with MTF and TA-Lib Integration
+- **Scope**: Implements 140+ technical features, multi-timeframe support (M1 to D1), and robust TA-Lib integration with look-ahead bias prevention.
+- **Domains**: Core Trading, Research, Analytics
+- **CI Status**: Pending (Author reports 251 tests pass locally)
+- **Missing Items**: Performance benchmarks for high-frequency feature calculation.
+- **Recommendation**: High-risk — needs domain expert review
 
 ---
 *Prepared by Jules06 (qufuwan) for Jules05 and human review.*


### PR DESCRIPTION
Update the daily merge-readiness checklist for May 4, 2026. This run focuses on three promising candidates: dependency bumps for Ruff and Joblib (Safe Surface), and a significant Institutional Feature Engineering addition (High Risk/Medium Signal). The checklist provides scope summaries, domain mapping, CI status, and formal review recommendations to streamline the integration process for Jules05 and human reviewers.

---
*PR created automatically by Jules for task [12445261733220899344](https://jules.google.com/task/12445261733220899344) started by @triqbit*