### PR TITLE
🔐 Jules02: Security hardening — log sanitization and permission hardening

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ COPY main.py .
 COPY alembic.ini .
 
 # Create log directory with proper permissions
-RUN mkdir -p /app/logs && chmod 777 /app/logs
+RUN mkdir -p /app/logs && chmod 755 /app/logs
 
 # Setup non-root user for production security
 RUN useradd -m -u 1000 trader && \

--- a/docs/operations/LOG_SANITIZATION.md
+++ b/docs/operations/LOG_SANITIZATION.md
@@ -1,0 +1,45 @@
+# Log Sanitization and Secret Masking
+
+## Overview
+
+To ensure production safety and prevent the accidental exposure of sensitive credentials, the MT5 AI Trading Bot implements a centralized **Secret Masking Processor** within its logging pipeline.
+
+This system automatically redacts sensitive information such as:
+- MetaTrader 5 account passwords
+- Database credentials (including those embedded in connection URLs)
+- Telegram bot tokens
+- MetaAPI authentication tokens
+
+## Implementation Details
+
+The sanitization logic resides in `src/core/log_config.py`. It uses a `SecretMaskingProcessor` integrated into the `structlog` configuration.
+
+### How it Works
+
+1.  **Dynamic Discovery**: At startup, the processor inspects the `TradingConfig` singleton.
+2.  **Type-Based Identification**: It identifies any fields annotated with `pydantic.SecretStr`.
+3.  **URL Parsing**: It specifically parses the `DATABASE_URL` using regex to extract and mask the password component while leaving the host and port visible for debugging.
+4.  **Runtime Redaction**: Every log event processed by `structlog` is scanned for these discovered secrets. Any occurrences are replaced with `[MASKED]`.
+
+## Configuration
+
+Sanitization is enabled by default in all modes (demo, live, backtest). It is configured within the `configure_logging` function in `main.py`.
+
+```python
+# Integration in main.py
+def configure_logging(level: str = "INFO") -> None:
+    structlog.configure(
+        processors=[
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.stdlib.add_log_level,
+            get_masking_processor(),  # The masking gate
+            structlog.dev.ConsoleRenderer(),
+        ],
+        ...
+    )
+```
+
+## Security Impact
+
+- **Secrets Exposure Prevention**: Reduces the risk of credentials leaking into persistent logs, ELK stacks, or developer consoles.
+- **Observability with Safety**: Allows for detailed "INFO" and "DEBUG" logging without fear of capturing raw passwords in exception traces or configuration summaries.

--- a/main.py
+++ b/main.py
@@ -34,7 +34,6 @@ from rich.table import Table
 
 from src.core import profile
 from src.core.audit_log import AuditLogger
-from src.core.log_config import get_masking_processor
 from src.core.config_validator import ConfigValidator
 from src.core.decision_support import DecisionSupportSystem
 from src.core.exceptions import (
@@ -45,6 +44,7 @@ from src.core.exceptions import (
 from src.core.explainability import SignalExplainer
 from src.core.feature_engineering import FeatureEngineer
 from src.core.health import HealthStatus, init_health_checker
+from src.core.log_config import get_masking_processor
 from src.core.monitor import Monitor
 from src.core.trade_logger import TradeLogger
 from src.data.event_intelligence import RiskStatus

--- a/main.py
+++ b/main.py
@@ -34,6 +34,7 @@ from rich.table import Table
 
 from src.core import profile
 from src.core.audit_log import AuditLogger
+from src.core.log_config import get_masking_processor
 from src.core.config_validator import ConfigValidator
 from src.core.decision_support import DecisionSupportSystem
 from src.core.exceptions import (
@@ -65,6 +66,7 @@ def configure_logging(level: str = "INFO") -> None:
         processors=[
             structlog.processors.TimeStamper(fmt="iso"),
             structlog.stdlib.add_log_level,
+            get_masking_processor(),
             structlog.dev.ConsoleRenderer(),
         ],
         wrapper_class=structlog.BoundLogger,
@@ -408,6 +410,7 @@ def main() -> int:
 
     try:
         cfg = get_config()
+        get_masking_processor().update_secrets(cfg)
     except Exception as exc:
         # Check if it's a Pydantic validation error (usually missing required fields)
         if "validation error" in str(exc).lower():

--- a/src/core/log_config.py
+++ b/src/core/log_config.py
@@ -8,8 +8,6 @@ from __future__ import annotations
 import re
 from typing import Any
 
-from pydantic import SecretStr
-
 from src.core.config import TradingConfig
 
 

--- a/src/core/log_config.py
+++ b/src/core/log_config.py
@@ -1,0 +1,72 @@
+"""
+Security-hardened logging configuration for MT5 AI Trading Bot.
+src/core/log_config.py
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from pydantic import SecretStr
+
+from src.core.config import TradingConfig
+
+
+class SecretMaskingProcessor:
+    """
+    Structlog processor that masks sensitive values in log events.
+    Dynamically retrieves secrets from TradingConfig to ensure any
+    SecretStr field is never leaked to logs.
+    """
+
+    def __init__(self, config: TradingConfig | None = None, mask: str = "[MASKED]") -> None:
+        self.mask = mask
+        self.secrets: set[str] = set()
+        if config:
+            self.update_secrets(config)
+
+    def update_secrets(self, config: TradingConfig) -> None:
+        """Extract all SecretStr values from the config."""
+        # Use the class's model_fields to avoid Pydantic 2.11+ instance attribute warning
+        for field_name, field_info in config.__class__.model_fields.items():
+            # Check if SecretStr is in the type annotation
+            annotation_str = str(field_info.annotation)
+            if "SecretStr" in annotation_str:
+                val = getattr(config, field_name)
+                if hasattr(val, "get_secret_value"):
+                    secret_val = val.get_secret_value()
+                    if secret_val and len(secret_val) > 3:
+                        self.secrets.add(secret_val)
+                elif isinstance(val, str) and val and len(val) > 3:
+                    self.secrets.add(val)
+
+        # Also specifically check database_url for embedded passwords
+        db_url = config.database_url.get_secret_value() if hasattr(config.database_url, "get_secret_value") else str(config.database_url)
+        if db_url and "@" in db_url:
+            # Mask the password part of the URL specifically
+            # postgresql://user:password@host:port/db
+            match = re.search(r"://([^:]+):([^@]+)@", db_url)
+            if match:
+                self.secrets.add(match.group(2))
+
+    def __call__(self, logger: Any, method_name: str, event_dict: dict[str, Any]) -> dict[str, Any]:
+        if not self.secrets:
+            return event_dict
+
+        new_dict = event_dict.copy()
+        for key, value in new_dict.items():
+            if isinstance(value, str):
+                for secret in self.secrets:
+                    if secret in value:
+                        new_dict[key] = new_dict[key].replace(secret, self.mask)
+
+        return new_dict
+
+
+_masking_processor = SecretMaskingProcessor()
+
+
+def get_masking_processor() -> SecretMaskingProcessor:
+    """Retrieve the global masking processor instance."""
+    return _masking_processor

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -1,0 +1,89 @@
+"""
+Security hardening tests for MT5 AI Trading Bot.
+tests/test_security_hardening.py
+"""
+
+import pytest
+import structlog
+from pydantic import SecretStr
+from io import StringIO
+import json
+
+from src.core.config import TradingConfig
+from src.core.log_config import SecretMaskingProcessor
+
+
+def test_secret_masking_processor(monkeypatch):
+    # Ensure environment variables don't override our test values
+    monkeypatch.setenv("MT5_PASSWORD", "supersecretpassword123")
+    monkeypatch.setenv("MT5_SERVER", "DemoServer")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://trader:dbpassword456@localhost:5432/db")
+
+    # 1. Setup config with secrets
+    config = TradingConfig(
+        mt5_login=12345,
+        mt5_password=SecretStr("supersecretpassword123"),
+        mt5_server="DemoServer",
+        database_url=SecretStr("postgresql://trader:dbpassword456@localhost:5432/db")
+    )
+
+    # 2. Initialize processor
+    processor = SecretMaskingProcessor(config=config)
+
+    # 3. Test cases for masking
+    test_event = {
+        "message": "Connecting with supersecretpassword123",
+        "db": "Using password dbpassword456 for connection",
+        "safe": "This is a safe message"
+    }
+
+    processed = processor(None, "info", test_event)
+
+    assert processed["message"] == "Connecting with [MASKED]"
+    assert processed["db"] == "Using password [MASKED] for connection"
+    assert processed["safe"] == "This is a safe message"
+    assert "supersecretpassword123" not in processed["message"]
+    assert "dbpassword456" not in processed["db"]
+
+
+def test_structlog_integration(monkeypatch):
+    # Ensure environment variables don't override our test values
+    monkeypatch.setenv("MT5_PASSWORD", "loggingsecret789")
+    monkeypatch.setenv("MT5_SERVER", "DemoServer")
+
+    # 1. Setup a custom logger to capture output
+    output = StringIO()
+
+    # Custom config for testing
+    config = TradingConfig(
+        mt5_login=12345,
+        mt5_password=SecretStr("loggingsecret789"),
+        mt5_server="DemoServer"
+    )
+
+    masker = SecretMaskingProcessor(config=config)
+
+    structlog.configure(
+        processors=[
+            masker,
+            structlog.processors.JSONRenderer()
+        ],
+        logger_factory=structlog.PrintLoggerFactory(output)
+    )
+
+    logger = structlog.get_logger()
+    logger.info("attempting_login", password="loggingsecret789")
+
+    # 2. Verify output
+    log_content = json.loads(output.getvalue())
+    assert log_content["password"] == "[MASKED]"
+    assert "loggingsecret789" not in output.getvalue()
+
+
+def test_dockerfile_permissions():
+    """Verify Dockerfile hardening via file content check."""
+    with open("Dockerfile", "r") as f:
+        content = f.read()
+
+    assert "chmod 755 /app/logs" in content
+    assert "chmod 777 /app/logs" not in content


### PR DESCRIPTION
### 🔐 Jules02: Security hardening — log sanitization and permission hardening

#### Risk/Quality Gap Identified
1. **Secrets Exposure:** Autonomous trading bots handle highly sensitive credentials (MT5 passwords, DB tokens). Standard logging can accidentally leak these secrets if developers log the configuration object or if exceptions capture sensitive state.
2. **Insecure File Permissions:** The `Dockerfile` previously used `chmod 777` for the logs directory, which violated the principle of least privilege and increased the risk of log tampering.

#### Changes Implemented
1. **Log Sanitization:**
   - Created `src/core/log_config.py` with a `SecretMaskingProcessor`.
   - The processor dynamically inspects `TradingConfig` (using Pydantic metadata) to identify all `SecretStr` values.
   - It also performs targeted regex masking on `database_url` to redact embedded passwords.
   - Integrated this processor into the `structlog` pipeline in `main.py`.
2. **Permission Hardening:**
   - Modified `Dockerfile` to use `chmod 755` for `/app/logs`, ensuring appropriate access control for the non-root `trader` user.

#### Validation Performed
- **Automated Testing:** Created `tests/test_security_hardening.py` to verify:
  - Processor correctly redacts multiple secrets from different log keys.
  - Integration with `structlog` correctly produces masked JSON output.
  - `Dockerfile` contains the intended `755` permission setting.
- **Regression Testing:** Ran `tests/test_config.py` and `tests/test_config_validator.py` to ensure no impact on core startup logic.
- **Manual Debugging:** Used a debug script to verify that Pydantic `SecretStr` fields are correctly identified and their values extracted for masking.

#### Out of Scope
- Rotation of existing credentials.
- Hardening of external services (PostgreSQL/MetaAPI) beyond connection-string sanitization.

#### Follow-up Recommendation
- Periodically audit new configuration fields to ensure they are marked as `SecretStr` if they contain sensitive data.

---
*PR created automatically by Jules for task [12402984748951140645](https://jules.google.com/task/12402984748951140645) started by @xnessom*