### PR TITLE
🛠️ Jules02: Resilience improvement — Granular error classification and conditional retries

### DIFF
--- a/docs/operations/RESILIENCE.md
+++ b/docs/operations/RESILIENCE.md
@@ -4,7 +4,7 @@ This document outlines the resilience and error-handling standards for the MT5 A
 
 ## Exception Hierarchy
 
-All custom exceptions inherit from `TradingError` in `src/core/exceptions.py`.
+All custom exceptions inherit from `TradingError` in `src/core/exceptions.py`. Each exception carries a `retriable` boolean flag to indicate if a recovery attempt is appropriate.
 
 - `TradingError`: Base exception.
 - `MT5Error`: Base for MT5-specific issues.
@@ -22,6 +22,7 @@ Used to wrap functions that interact with external services. Features include:
 - **Exponential Backoff**: Delay increases after each failure.
 - **Jitter**: Random noise added to delays to prevent thundering herd problems.
 - **Max Retries**: Configurable limit (default: 3).
+- **Conditional Retries**: Supports a `retry_if` predicate to decide whether to retry based on the specific exception instance (e.g., only if `retriable=True`).
 
 ### Application
 
@@ -33,4 +34,4 @@ Used to wrap functions that interact with external services. Features include:
 The main trading loop in `main.py` is hardened against crashes:
 - Catching `MT5DataError` skips the current iteration and waits for the next cycle.
 - Catching `MT5ConnectionError` triggers an active reconnection attempt.
-- Critical execution errors are logged but don't halt the entire system.
+- Catching `MT5ExecutionError` distinguishes between transient (retriable) and permanent failures to inform operator logging and recovery flow.

--- a/main.py
+++ b/main.py
@@ -301,7 +301,13 @@ def run_live(
                         try:
                             ticket = connector.place_order(signal)
                         except MT5ExecutionError as e:
-                            log.error("Order execution FAILED: %s", e)
+                            if getattr(e, "retriable", False):
+                                log.warning(
+                                    "Order execution REJECTED (transient): %s. Signal skipped.",
+                                    e,
+                                )
+                            else:
+                                log.error("Order execution FAILED (permanent): %s", e)
                             ticket = None
 
                         if ticket:

--- a/src/core/exceptions.py
+++ b/src/core/exceptions.py
@@ -10,9 +10,15 @@ Centralized exception hierarchy for robust error handling and recovery.
 
 class TradingError(Exception):
     """Base exception for all trading-related errors."""
-    def __init__(self, message: str, details: dict[str, Any] | None = None):
+    def __init__(
+        self,
+        message: str,
+        details: dict[str, Any] | None = None,
+        retriable: bool = False,
+    ):
         super().__init__(message)
         self.details = details or {}
+        self.retriable = retriable
 
 
 class MT5Error(TradingError):

--- a/src/core/retry.py
+++ b/src/core/retry.py
@@ -19,6 +19,7 @@ def with_retry(
     initial_delay: float = 1.0,
     backoff_factor: float = 2.0,
     jitter: bool = True,
+    retry_if: Callable[[Any], bool] | None = None,
 ):
     """
     Decorator for retrying a function with exponential backoff.
@@ -29,6 +30,7 @@ def with_retry(
         initial_delay: Initial delay between retries in seconds.
         backoff_factor: Multiplier for the delay after each retry.
         jitter: Whether to add random jitter to the delay.
+        retry_if: Optional callable that takes the exception and returns True if it should be retried.
     """
     def decorator(func: Callable):
         @functools.wraps(func)
@@ -39,6 +41,9 @@ def with_retry(
                 try:
                     return func(*args, **kwargs)
                 except exceptions as e:
+                    if retry_if and not retry_if(e):
+                        raise
+
                     if attempt == max_retries:
                         logger.error(
                             "Max retries (%d) reached for %s. Last error: %s",

--- a/src/trading/mt5_connector.py
+++ b/src/trading/mt5_connector.py
@@ -193,12 +193,18 @@ class MT5Connector:
             rates = mt5.copy_rates_from_pos(symbol, tf, 0, n_bars)
             if rates is None:
                 error_code, error_desc = mt5.last_error()
-                # Most data errors in MT5 are transient (connection, busy)
+                # Most data errors in MT5 are transient (connection, busy, or timeout)
+                # Code 2 is common for transient network issues.
                 retriable = error_code in [
+                    2,
                     mt5.TRADE_RETCODE_CONNECTION,
                     mt5.TRADE_RETCODE_TIMEOUT,
                     -5,  # Not found might be transient if terminal is rebooting
                 ]
+                # Default to retriable for data fetch as it's safe and likely transient
+                if error_code == 0:
+                    retriable = True
+
                 raise MT5DataError(
                     f"Failed to copy rates: {error_desc} (code: {error_code})",
                     retriable=retriable,
@@ -275,10 +281,15 @@ class MT5Connector:
             tick = mt5.symbol_info_tick(symbol)
             if tick is None:
                 error_code, error_desc = mt5.last_error()
+                # Transient network/timeout or symbol busy
                 retriable = error_code in [
+                    2,
                     mt5.TRADE_RETCODE_CONNECTION,
                     mt5.TRADE_RETCODE_TIMEOUT,
                 ]
+                if error_code == 0:
+                    retriable = True
+
                 raise MT5DataError(
                     f"Failed to get tick: {error_desc} (code: {error_code})",
                     retriable=retriable,

--- a/src/trading/mt5_connector.py
+++ b/src/trading/mt5_connector.py
@@ -177,7 +177,9 @@ class MT5Connector:
         finally:
             self.shutdown()
 
-    @with_retry(MT5DataError, max_retries=3)
+    @with_retry(
+        MT5DataError, max_retries=3, retry_if=lambda e: getattr(e, "retriable", True)
+    )
     def get_rates(self, symbol: str, timeframe: str, n_bars: int) -> pd.DataFrame:
         """
         Fetch historical OHLCV data.
@@ -190,16 +192,37 @@ class MT5Connector:
         if not self.use_metaapi:
             rates = mt5.copy_rates_from_pos(symbol, tf, 0, n_bars)
             if rates is None:
-                raise MT5DataError(f"Failed to copy rates: {mt5.last_error()}")
+                error_code, error_desc = mt5.last_error()
+                # Most data errors in MT5 are transient (connection, busy)
+                retriable = error_code in [
+                    mt5.TRADE_RETCODE_CONNECTION,
+                    mt5.TRADE_RETCODE_TIMEOUT,
+                    -5,  # Not found might be transient if terminal is rebooting
+                ]
+                raise MT5DataError(
+                    f"Failed to copy rates: {error_desc} (code: {error_code})",
+                    retriable=retriable,
+                )
             df = pd.DataFrame(rates)
             df["time"] = pd.to_datetime(df["time"], unit="s")
             return df
         else:
+
             async def _get_rates():
-                candles = await self.metaapi_connection.get_historical_candles(
-                    symbol, timeframe, None, n_bars
-                )
-                return candles
+                try:
+                    candles = await self.metaapi_connection.get_historical_candles(
+                        symbol, timeframe, None, n_bars
+                    )
+                    return candles
+                except Exception as e:
+                    error_msg = str(e).lower()
+                    retriable = any(
+                        kw in error_msg
+                        for kw in ["timeout", "connection", "rate limit", "busy"]
+                    )
+                    raise MT5DataError(
+                        f"MetaAPI rates fetch failed: {e}", retriable=retriable
+                    ) from e
 
             candles = asyncio.run(_get_rates())
             df = pd.DataFrame(candles)
@@ -240,7 +263,9 @@ class MT5Connector:
                 df["time"] = pd.to_datetime(df["time"])
             return df
 
-    @with_retry(MT5DataError, max_retries=2)
+    @with_retry(
+        MT5DataError, max_retries=2, retry_if=lambda e: getattr(e, "retriable", True)
+    )
     def get_tick(self, symbol: str) -> dict[str, float]:
         """Retrieve latest symbol tick."""
         if not self._is_initialized:
@@ -249,22 +274,48 @@ class MT5Connector:
         if not self.use_metaapi:
             tick = mt5.symbol_info_tick(symbol)
             if tick is None:
-                raise MT5DataError(f"Failed to get tick: {mt5.last_error()}")
+                error_code, error_desc = mt5.last_error()
+                retriable = error_code in [
+                    mt5.TRADE_RETCODE_CONNECTION,
+                    mt5.TRADE_RETCODE_TIMEOUT,
+                ]
+                raise MT5DataError(
+                    f"Failed to get tick: {error_desc} (code: {error_code})",
+                    retriable=retriable,
+                )
             return {"bid": tick.bid, "ask": tick.ask, "spread": tick.ask - tick.bid}
         else:
+
             async def _get_tick():
-                await self.metaapi_connection.get_symbol_specification(symbol)
-                price = await self.metaapi_connection.get_symbol_price(symbol)
-                return {
-                    "bid": price["bid"],
-                    "ask": price["ask"],
-                    "spread": price["ask"] - price["bid"]
-                }
+                try:
+                    await self.metaapi_connection.get_symbol_specification(symbol)
+                    price = await self.metaapi_connection.get_symbol_price(symbol)
+                    return {
+                        "bid": price["bid"],
+                        "ask": price["ask"],
+                        "spread": price["ask"] - price["bid"],
+                    }
+                except Exception as e:
+                    error_msg = str(e).lower()
+                    retriable = any(
+                        kw in error_msg
+                        for kw in ["timeout", "connection", "rate limit", "busy"]
+                    )
+                    raise MT5DataError(
+                        f"MetaAPI tick fetch failed: {e}", retriable=retriable
+                    ) from e
+
             return asyncio.run(_get_tick())
 
+    @with_retry(
+        MT5ExecutionError,
+        max_retries=2,
+        retry_if=lambda e: getattr(e, "retriable", False),
+    )
     def place_order(self, signal: TradeSignal) -> int | None:
         """
         Execute a market order based on a validated trade signal.
+        Retries on transient errors (requotes, price changes).
 
         Args:
             signal: Validated TradeSignal object.
@@ -273,7 +324,7 @@ class MT5Connector:
             Order ticket ID if successful.
 
         Raises:
-            MT5ExecutionError: If order placement fails.
+            MT5ExecutionError: If order placement fails permanently.
         """
         if not self._is_initialized:
             raise MT5ConnectionError("MT5 connector not initialized.")
@@ -302,16 +353,42 @@ class MT5Connector:
 
             result = mt5.order_send(request)
             if result.retcode != mt5.TRADE_RETCODE_DONE:
-                raise MT5ExecutionError(f"Order rejected: {result.comment}")
+                retriable = result.retcode in [
+                    mt5.TRADE_RETCODE_REQUOTE,
+                    mt5.TRADE_RETCODE_PRICE_CHANGED,
+                    mt5.TRADE_RETCODE_CONNECTION,
+                    mt5.TRADE_RETCODE_TIMEOUT,
+                    mt5.TRADE_RETCODE_PRICE_OFF,
+                ]
+                raise MT5ExecutionError(
+                    f"Order rejected: {result.comment} (code: {result.retcode})",
+                    retriable=retriable,
+                )
             return int(result.order)
         else:
+
             async def _place_order():
-                action = 'BUY' if signal.direction > 0 else 'SELL'
-                result = await self.metaapi_connection.create_market_order(
-                    signal.symbol, action, signal.lot_size, signal.stop_loss,
-                    signal.take_profit, {'comment': f'AI:{signal.algorithm}'}
-                )
-                return int(result['orderId'])
+                try:
+                    action = "BUY" if signal.direction > 0 else "SELL"
+                    result = await self.metaapi_connection.create_market_order(
+                        signal.symbol,
+                        action,
+                        signal.lot_size,
+                        signal.stop_loss,
+                        signal.take_profit,
+                        {"comment": f"AI:{signal.algorithm}"},
+                    )
+                    return int(result["orderId"])
+                except Exception as e:
+                    error_msg = str(e).lower()
+                    retriable = any(
+                        kw in error_msg
+                        for kw in ["timeout", "connection", "rate limit", "busy"]
+                    )
+                    raise MT5ExecutionError(
+                        f"MetaAPI order failed: {e}", retriable=retriable
+                    ) from e
+
             return asyncio.run(_place_order())
 
     def get_account_info(self) -> dict[str, Any]:

--- a/tests/test_resilience_new.py
+++ b/tests/test_resilience_new.py
@@ -1,0 +1,54 @@
+import pytest
+from unittest.mock import MagicMock
+from src.core.retry import with_retry
+from src.core.exceptions import MT5Error, MT5ExecutionError
+
+def test_retry_if_retriable_true():
+    mock_func = MagicMock(side_effect=[
+        MT5ExecutionError("transient", retriable=True),
+        "success"
+    ])
+
+    @with_retry(MT5ExecutionError, retry_if=lambda e: getattr(e, "retriable", False), max_retries=2, initial_delay=0.01)
+    def call_me():
+        return mock_func()
+
+    assert call_me() == "success"
+    assert mock_func.call_count == 2
+
+def test_retry_if_retriable_false():
+    mock_func = MagicMock(side_effect=[
+        MT5ExecutionError("permanent", retriable=False),
+        "success"
+    ])
+
+    @with_retry(MT5ExecutionError, retry_if=lambda e: getattr(e, "retriable", False), max_retries=2, initial_delay=0.01)
+    def call_me():
+        return mock_func()
+
+    with pytest.raises(MT5ExecutionError) as exc:
+        call_me()
+
+    assert "permanent" in str(exc.value)
+    assert mock_func.call_count == 1
+
+def test_retry_if_none_always_retries():
+    # Backward compatibility check
+    mock_func = MagicMock(side_effect=[
+        ValueError("fail"),
+        "success"
+    ])
+
+    @with_retry(ValueError, max_retries=2, initial_delay=0.01)
+    def call_me():
+        return mock_func()
+
+    assert call_me() == "success"
+    assert mock_func.call_count == 2
+
+def test_mt5_error_retriable_attribute():
+    err = MT5Error("msg", retriable=True)
+    assert err.retriable is True
+
+    err2 = MT5ExecutionError("msg", retriable=False)
+    assert err2.retriable is False


### PR DESCRIPTION
### Resilience improvement — Granular error classification and conditional retries

**Risk/Quality Gap:**
The previous implementation lacked granular distinction between transient (retriable) and permanent failures. Data retrieval and order execution errors would often either fail silently or crash the trading cycle, potentially leading to missed opportunities or unsafe execution states. MetaAPI failures were also not properly mapped to the internal exception hierarchy.

**Changes:**
1.  **Core Persistence & Logic**: Added a `retriable` boolean flag to the `TradingError` base class and its subclasses in `src/core/exceptions.py`.
2.  **Robust Retry Mechanism**: Enhanced the `@with_retry` decorator in `src/core/retry.py` with a `retry_if` predicate, allowing decorators to decide whether to retry based on the specific exception instance.
3.  **Harden MT5Connector**:
    -   Mapped MT5 return codes (e.g., `REQUOTE`, `TIMEOUT`, `CONNECTION`) to the `retriable` flag.
    -   Wrapped MetaAPI calls in try-except blocks to classify network/timeout errors as retriable `MT5DataError` or `MT5ExecutionError`.
    -   Applied conditional retries to `place_order`, `get_rates`, and `get_tick`.
4.  **Trading Loop Optimization**: Updated the main loop in `main.py` to provide better operator visibility into the type of failure (Warning for transient, Error for permanent) and ensure continued operation after recoverable execution rejections.

**Validation:**
-   Created `tests/test_resilience_new.py` to verify the `retry_if` logic and exception metadata.
-   Ran existing core tests (config, monitor, risk) to ensure no regressions.
-   Verified changes manually via `read_file`.

**Out of Scope:**
-   Full implementation of order state verification (reconciliation) after a timeout is not included in this PR but is recommended for future hardening.
-   SQLite persistence resilience (database locking) was considered but postponed to keep the diff focused on the trading path.

**Follow-up Recommendation:**
Implement a `reconcile_orders` check in the `MT5Connector` to be called after an execution timeout, ensuring that a "missing" ticket response didn't actually result in an open position on the server.

---
*PR created automatically by Jules for task [5696228263120657988](https://jules.google.com/task/5696228263120657988) started by @xnessom*