### PR TITLE
🧪 Jules02: Integration test coverage — Enterprise Decision & Audit Flow

### DIFF
--- a/docs/quality/UX_IMPROVEMENTS.md
+++ b/docs/quality/UX_IMPROVEMENTS.md
@@ -40,3 +40,8 @@ Fixed cache invalidation logic ensuring that CLI flags (e.g., `--algo ensemble`)
 - Reduced troubleshooting time for environment setup.
 - Clearer path to production compliance with policy-based risk warnings.
 - Predictable CLI behavior for automated scripting.
+
+### 5. Enterprise Audit Visibility
+Enhanced the traceability of trading decisions by integrating the `ExecutionFilter` and `AuditedRiskManager` with the `AuditLogger`.
+- **Decision Traceability**: Every rejection now includes a detailed trace (e.g., 'TREND_ANGLE', 'risk_reward') persisted in the database.
+- **Integration Testing**: Verified the cross-module decision flow from Signal to Audit Persistence to prevent observability regressions.

--- a/src/trading/execution_filter.py
+++ b/src/trading/execution_filter.py
@@ -116,7 +116,7 @@ class ExecutionFilter:
         trace["confidence_threshold"] = {
             "passed": conf_passed,
             "confidence": signal.confidence,
-            "threshold": self.cfg.confidence_threshold if self.cfg else 0.0,
+            "threshold": self.cfg.min_confidence if self.cfg else 0.0,
         }
 
         # Determine final approval
@@ -341,7 +341,7 @@ class ExecutionFilter:
         """Enforces configured confidence threshold."""
         if self.cfg is None:
             return True
-        return confidence >= self.cfg.confidence_threshold
+        return confidence >= self.cfg.min_confidence
 
     def _check_session_time(self, timestamp: datetime) -> bool:
         """Blocks outside institutional trading hours (Sun 17:00 - Fri 16:00 GMT)."""

--- a/tests/test_enterprise_audit_integration.py
+++ b/tests/test_enterprise_audit_integration.py
@@ -1,0 +1,191 @@
+"""
+MT5 AI/ML Trading Bot - Enterprise Integration Test
+tests/test_enterprise_audit_integration.py
+
+Verifies the Enterprise Decision & Audit Flow:
+Model Inference -> Execution Filter -> Audited Risk Manager -> Audit Persistence
+
+Protects: Cross-module blocking reason propagation and audit traceability.
+"""
+
+import os
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pandas as pd
+import pytest
+from sqlalchemy import select
+
+# Standardize mocks for use across all tests and imports
+mock_torch = MagicMock()
+class MockTensor: pass
+mock_torch.Tensor = MockTensor
+mock_sb3 = MagicMock()
+mock_talib = MagicMock()
+
+with patch.dict("sys.modules", {
+    "torch": mock_torch,
+    "torch.nn": mock_torch.nn,
+    "stable_baselines3": mock_sb3,
+    "talib": mock_talib
+}):
+    from src.core.audit_log import AuditEntry, AuditLogger
+    from src.core.config import get_config
+    from src.core.constants import SignalDirection
+    from src.trading.audited_risk_manager import AuditedRiskManager
+    from src.trading.execution_filter import ExecutionFilter
+    from src.trading.risk_manager import TradeSignal
+
+@pytest.fixture(autouse=True)
+def reset_audit_logger():
+    """Reset the AuditLogger singleton before each test."""
+    AuditLogger._instance = None
+    AuditLogger._initialized = False
+
+@pytest.fixture
+def audit_logger():
+    """Provide a fresh in-memory AuditLogger."""
+    return AuditLogger(db_url="sqlite:///:memory:")
+
+@pytest.fixture
+def mock_cfg():
+    with patch.dict(os.environ, {
+        "MT5_PASSWORD": "test_password",
+        "MT5_SERVER": "test_server",
+        "TELEGRAM_TOKEN": "123:abc",
+        "TELEGRAM_CHAT_ID": "123456",
+        "MODE": "demo",
+        "MIN_CONFIDENCE": "0.7"
+    }):
+        get_config.cache_clear()
+        return get_config()
+
+def test_enterprise_audit_flow_double_rejection(mock_cfg, audit_logger):
+    """
+    Scenario: Signal is generated, but fails both Execution Filter and Risk Manager.
+    Verifies that BOTH components log their detailed traces to the audit DB.
+    """
+    # 1. Setup Signal
+    signal = TradeSignal(
+        symbol="XAUUSD",
+        direction=SignalDirection.BUY.value,
+        entry_price=2300.0,
+        stop_loss=2295.0,  # Tight SL
+        take_profit=2302.0, # Low TP (R:R = 2/5 = 0.4)
+        lot_size=0.1,
+        algorithm="ensemble",
+        confidence=0.85
+    )
+
+    # 2. Setup Market Data that fails Trend Angle (Moving Average is going down)
+    df = pd.DataFrame({
+        "close": np.linspace(2310, 2300, 100), # Downtrend
+        "high": np.linspace(2315, 2305, 100),
+        "low": np.linspace(2305, 2295, 100),
+        "base_M5_ema_21": np.linspace(2310, 2300, 100) # EMA 21 following downtrend
+    })
+
+    # 3. Execution Filter Validation (Should fail TREND_ANGLE)
+    execution_filter = ExecutionFilter(config=mock_cfg)
+    ef_decision = execution_filter.validate(signal, df, current_drawdown=0.0)
+
+    assert ef_decision.is_approved is False
+    assert ef_decision.blocked_by == "TREND_ANGLE"
+
+    # Log EF decision manually as main.py would
+    audit_logger.log_execution_decision(
+        symbol=signal.symbol,
+        direction=signal.direction,
+        trace=ef_decision.trace,
+        is_approved=ef_decision.is_approved
+    )
+
+    # 4. Audited Risk Manager Validation (Should fail risk_reward)
+    risk_manager = AuditedRiskManager(mock_cfg, account_balance=10000.0)
+    # AuditedRiskManager.approve calls audit_logger.log_risk_decision internally
+    risk_approved = risk_manager.approve(signal)
+
+    assert risk_approved is False
+
+    # 5. Verify Audit Persistence
+    with audit_logger.Session() as session:
+        # Check Execution Decision Entry
+        ef_entry = session.execute(
+            select(AuditEntry).where(AuditEntry.action == "execution_decision")
+        ).scalar_one()
+        assert ef_entry.metadata_json["is_approved"] is False
+        assert ef_entry.metadata_json["trace"]["trend_angle"]["passed"] is False
+        assert ef_entry.metadata_json["symbol"] == "XAUUSD"
+
+        # Check Risk Decision Entry
+        risk_entry = session.execute(
+            select(AuditEntry).where(AuditEntry.action == "risk_decision")
+        ).scalar_one()
+        assert risk_entry.metadata_json["passed"] is False
+        assert risk_entry.metadata_json["decision_chain"]["risk_reward"] is False
+        assert risk_entry.metadata_json["decision_chain"]["circuit_breaker"] is True
+
+def test_enterprise_audit_flow_execution_pass_risk_fail(mock_cfg, audit_logger):
+    """
+    Scenario: Execution filter passes but Risk Manager rejects.
+    Verifies that the audit trail correctly distinguishes where the trade was blocked.
+    """
+    # 1. Setup Signal
+    signal = TradeSignal(
+        symbol="XAUUSD",
+        direction=SignalDirection.BUY.value,
+        entry_price=2300.0,
+        stop_loss=2299.0,  # Very tight SL
+        take_profit=2300.5, # Tiny profit (R:R = 0.5)
+        lot_size=0.1,
+        algorithm="ensemble",
+        confidence=0.85
+    )
+
+    # 2. Market data that passes (Uptrend)
+    df = pd.DataFrame({
+        "close": np.linspace(2290, 2300, 100),
+        "high": np.linspace(2295, 2305, 100),
+        "low": np.linspace(2285, 2295, 100),
+        "base_M5_ema_21": np.linspace(2290, 2300, 100),
+        "base_M5_ema_8": np.linspace(2295, 2305, 100),
+        "base_M5_ema_50": np.linspace(2280, 2290, 100),
+        "base_M5_ema_200": np.linspace(2270, 2280, 100),
+        "base_M5_rsi": [60.0] * 100,
+        "base_M5_atr": [1.0] * 100
+    })
+
+    # 3. Execution Filter Validation (Should PASS)
+    execution_filter = ExecutionFilter(config=mock_cfg)
+    ef_decision = execution_filter.validate(signal, df, current_drawdown=0.0)
+
+    assert ef_decision.is_approved is True
+
+    audit_logger.log_execution_decision(
+        symbol=signal.symbol,
+        direction=signal.direction,
+        trace=ef_decision.trace,
+        is_approved=ef_decision.is_approved
+    )
+
+    # 4. Audited Risk Manager Validation (Should FAIL on risk_reward)
+    risk_manager = AuditedRiskManager(mock_cfg, account_balance=10000.0)
+    risk_approved = risk_manager.approve(signal)
+
+    assert risk_approved is False
+
+    # 5. Verify Audit Persistence
+    with audit_logger.Session() as session:
+        # Check Execution Decision (Passed)
+        ef_entry = session.execute(
+            select(AuditEntry).where(AuditEntry.action == "execution_decision")
+        ).scalar_one()
+        assert ef_entry.metadata_json["is_approved"] is True
+
+        # Check Risk Decision (Failed)
+        risk_entry = session.execute(
+            select(AuditEntry).where(AuditEntry.action == "risk_decision")
+        ).scalar_one()
+        assert risk_entry.metadata_json["passed"] is False
+        assert risk_entry.metadata_json["decision_chain"]["risk_reward"] is False

--- a/tests/test_execution_traceability.py
+++ b/tests/test_execution_traceability.py
@@ -14,7 +14,7 @@ class MockConfig:
         self.model_drift_threshold = 0.3
         self.model_accuracy_floor = 0.45
         self.model_win_rate_floor = 0.40
-        self.confidence_threshold = 0.6
+        self.min_confidence = 0.6
         self.logs_dir = "logs"
 
 @pytest.fixture


### PR DESCRIPTION
I have implemented a new high-value integration test that verifies the full decision and audit flow of the trading system. 

### Risk or Quality Gap
Previously, while individual components like `ExecutionFilter` and `AuditedRiskManager` were tested in isolation, there was no end-to-end integration test verifying that blocking reasons from the filters were correctly propagated and persisted in the Audit database during a unified flow. Additionally, a bug was discovered where `ExecutionFilter` was attempting to access a non-existent configuration attribute.

### Changes
- **Bug Fix**: Corrected `src/trading/execution_filter.py` to use `min_confidence` instead of `confidence_threshold`, aligning it with the `TradingConfig` schema.
- **Integration Test**: Created `tests/test_enterprise_audit_integration.py`. This test simulates signals passing through the `ExecutionFilter` and `AuditedRiskManager`, asserting that:
    - Detailed traces (e.g., trend angle analysis, R:R ratios) are correctly captured.
    - Decisions are persisted in the `audit_log` table with the correct status and metadata.
    - Rejection reasons are correctly attributed to the responsible component.
- **Maintenance**: Updated `tests/test_execution_traceability.py` to use the correct attribute name in its mock configuration.

### Validation
- Created and ran `tests/test_enterprise_audit_integration.py` successfully.
- Verified that the audit trail reflects multiple rejection scenarios (Double rejection by Filter+Risk, and single rejection by Risk after Filter passing).
- Ran existing integration tests (`tests/test_data_pipeline_integration.py`, `tests/test_decision_pipeline_integration.py`, `tests/test_execution_traceability.py`) to ensure no regressions were introduced.

### Follow-up Recommendation
Future work could extend this flow to include the `TradeLogger`'s signal logging to ensure a complete "Signal -> Audit -> Trade" lineage is established in the database for every attempt.

---
*PR created automatically by Jules for task [11959172569749941356](https://jules.google.com/task/11959172569749941356) started by @xnessom*