### PR TITLE
Implement Data Retention Policy and Automated Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ htmlcov/
 *.tfstate.backup
 .terraform/
 releases/
+
+# Archives (Cleanup outputs)
+archives/

--- a/docs/DATA_RETENTION_POLICY.md
+++ b/docs/DATA_RETENTION_POLICY.md
@@ -12,9 +12,9 @@ This policy defines the retention periods and disposal procedures for operationa
 | **Audit** | Risk Events (`risk_events` table) | 2 Years | Purge | Operational Auditing |
 | **Audit** | Linked Model Signals | 7 Years | Archival + Purge | Trade Traceability |
 | **Operational** | Unlinked Model Signals | 90 Days | Purge | Performance Tuning |
-| **Operational** | Performance Metrics | 2 Years | Purge | Trend Analysis |
+| **Operational** | Performance Metrics | 2 Years | Archival + Purge | Trend Analysis |
 | **Diagnostics** | Application Logs (`logs/*.log`) | 90 Days | Deletion | Troubleshooting |
-| **Research** | Backtest Results | 1 Year | Deletion | Optimization |
+| **Research** | Backtest Results | 1 Year | Archival + Deletion | Optimization |
 
 ## 3. Data Classification
 
@@ -33,8 +33,10 @@ The following data can be purged more frequently to manage storage:
 ## 4. Archival and Purging Rules
 
 ### 4.1 Archival Procedures
-Prior to purging, data in the **Compliance** and **Audit (7-year)** categories must be archived:
-- **Format**: Data is exported to compressed CSV format.
+Prior to purging, data in the **Compliance**, **Audit**, **Operational (Performance Metrics)**, and **Research (Backtest Results)** categories must be archived:
+- **Format**:
+  - Database records are exported to compressed CSV format.
+  - Filesystem-based research data (Backtest Results) is bundled into compressed `.tar.gz` archives.
 - **Destination**: Archives are stored in the `archives/` directory or enterprise cold-storage (e.g., AWS S3 Glacier).
 - **Integrity**: SHA256 checksums are generated for each archive file to ensure immutability.
 

--- a/scripts/data_cleanup.py
+++ b/scripts/data_cleanup.py
@@ -8,6 +8,7 @@ import argparse
 import csv
 import hashlib
 import logging
+import tarfile
 import os
 import sys
 from datetime import datetime, timedelta, timezone
@@ -124,39 +125,68 @@ def cleanup_logs(logs_dir: Path, dry_run: bool = False) -> int:
     return count
 
 
-def cleanup_backtests(backtest_dir: Path, dry_run: bool = False) -> int:
-    """Delete backtest results older than RETENTION_BACKTESTS days."""
+def cleanup_backtests(backtest_dir: Path, dry_run: bool = False, archive_dir: Path = ARCHIVE_DIR) -> int:
+    """Archive and delete backtest results older than RETENTION_BACKTESTS days."""
     if not backtest_dir.exists():
         logger.info(f"Backtest directory {backtest_dir} does not exist. Skipping.")
         return 0
 
     count = 0
     cutoff = datetime.now() - timedelta(days=RETENTION_BACKTESTS)
+    to_cleanup = []
 
-    logger.info(f"Cleaning up backtest results in {backtest_dir} older than {cutoff.date()}...")
+    logger.info(f"Checking backtest results in {backtest_dir} older than {cutoff.date()}...")
 
-    # Recursively check for files and directories in backtest_dir
+    # Identify files to cleanup
     for item in backtest_dir.rglob("*"):
         if item.is_file():
             try:
                 mtime = datetime.fromtimestamp(item.stat().st_mtime)
                 if mtime < cutoff:
-                    logger.info(f"{'[DRY RUN] ' if dry_run else ''}Deleting old backtest file: {item.relative_to(backtest_dir)} (mtime: {mtime})")
-                    if not dry_run:
-                        item.unlink()
-                    count += 1
+                    to_cleanup.append(item)
             except Exception as e:
-                logger.error(f"Failed to delete backtest file {item}: {e}")
+                logger.error(f"Failed to check backtest file {item}: {e}")
+
+    if not to_cleanup:
+        return 0
+
+    # Archive before deletion
+    if not dry_run:
+        if not archive_dir.exists():
+            archive_dir.mkdir(parents=True, exist_ok=True)
+
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        archive_path = archive_dir / f"archive_backtests_{timestamp}.tar.gz"
+
+        logger.info(f"Archiving {len(to_cleanup)} backtest files to {archive_path}...")
+        try:
+            with tarfile.open(archive_path, "w:gz") as tar:
+                for item in to_cleanup:
+                    tar.add(item, arcname=item.relative_to(backtest_dir))
+
+            generate_checksum(archive_path)
+        except Exception as e:
+            logger.error(f"Failed to archive backtests: {e}")
+            return 0
+
+    # Delete files
+    for item in to_cleanup:
+        try:
+            logger.info(f"{'[DRY RUN] ' if dry_run else ''}Deleting old backtest file: {item.relative_to(backtest_dir)}")
+            if not dry_run:
+                item.unlink()
+            count += 1
+        except Exception as e:
+            logger.error(f"Failed to delete backtest file {item}: {e}")
 
     # After deleting files, attempt to delete empty directories
     for item in sorted(backtest_dir.rglob("*"), reverse=True):
         if item.is_dir() and item != backtest_dir and not any(item.iterdir()):
             try:
-                logger.info(f"{'[DRY RUN] ' if dry_run else ''}Deleting empty backtest directory: {item.relative_to(backtest_dir)}")
                 if not dry_run:
                     item.rmdir()
-            except Exception as e:
-                logger.error(f"Failed to delete directory {item}: {e}")
+            except Exception:
+                pass # Directory might not be empty or already deleted
 
     return count
 
@@ -228,8 +258,12 @@ def cleanup_database(db_url: str, audit_db_url: str = None, dry_run: bool = Fals
         if perf_records:
             logger.info(f"{'[DRY RUN] ' if dry_run else ''}Purging {len(perf_records)} performance metrics older than {perf_cutoff.date()}")
             if not dry_run:
-                for obj in perf_records:
-                    session.delete(obj)
+                # Archiving performance metrics (Operational 2-year category, archived before purge)
+                if archive_records(perf_records, "performance_metrics", archive_dir):
+                    for obj in perf_records:
+                        session.delete(obj)
+                else:
+                    logger.error("Skipping deletion of performance metrics due to archival failure.")
 
         # 4. Cleanup Trades (older than 7 years)
         trade_cutoff = now - timedelta(days=RETENTION_TRADES)
@@ -336,7 +370,7 @@ def main():
     logger.info(f"Log cleanup complete. Total files processed: {log_count}")
 
     # Filesystem cleanup - Backtests
-    backtest_count = cleanup_backtests(backtest_dir, dry_run=args.dry_run)
+    backtest_count = cleanup_backtests(backtest_dir, dry_run=args.dry_run, archive_dir=archive_dir)
     logger.info(f"Backtest cleanup complete. Total files processed: {backtest_count}")
 
     # Database cleanup

--- a/tests/test_data_cleanup_system.py
+++ b/tests/test_data_cleanup_system.py
@@ -1,0 +1,195 @@
+"""
+Tests for the Data Cleanup Script and Retention Policy Enforcement.
+"""
+
+import os
+import shutil
+import tarfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from scripts.data_cleanup import (
+    cleanup_backtests,
+    cleanup_database,
+    cleanup_logs,
+    RETENTION_LOGS,
+    RETENTION_UNLINKED_SIGNALS,
+    RETENTION_RISK_EVENTS,
+    RETENTION_PERFORMANCE_METRICS,
+    RETENTION_TRADES,
+    RETENTION_AUDIT_LOG,
+    RETENTION_BACKTESTS
+)
+from src.core.audit_log import AuditEntry, Base as AuditBase
+from src.core.trade_logger import (
+    Base as TradeBase,
+    ModelSignal,
+    PerformanceMetric,
+    RiskEvent,
+    Trade
+)
+
+@pytest.fixture
+def test_env(tmp_path):
+    """Setup a temporary environment for cleanup tests."""
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    backtest_dir = tmp_path / "backtests"
+    backtest_dir.mkdir()
+    archive_dir = tmp_path / "archives"
+    archive_dir.mkdir()
+
+    db_path = tmp_path / "test_trades.db"
+    db_url = f"sqlite:///{db_path}"
+
+    audit_db_path = tmp_path / "test_audit.db"
+    audit_db_url = f"sqlite:///{audit_db_path}"
+
+    # Initialize Databases
+    trade_engine = create_engine(db_url)
+    TradeBase.metadata.create_all(trade_engine)
+    TradeSession = sessionmaker(bind=trade_engine)
+
+    audit_engine = create_engine(audit_db_url)
+    AuditBase.metadata.create_all(audit_engine)
+    AuditSession = sessionmaker(bind=audit_engine)
+
+    return {
+        "logs_dir": logs_dir,
+        "backtest_dir": backtest_dir,
+        "archive_dir": archive_dir,
+        "db_url": db_url,
+        "audit_db_url": audit_db_url,
+        "TradeSession": TradeSession,
+        "AuditSession": AuditSession
+    }
+
+def test_cleanup_logs(test_env):
+    logs_dir = test_env["logs_dir"]
+
+    # Create old and new log files
+    old_log = logs_dir / "old.log"
+    old_log.write_text("old")
+    old_time = datetime.now() - timedelta(days=RETENTION_LOGS + 1)
+    os.utime(old_log, (old_time.timestamp(), old_time.timestamp()))
+
+    new_log = logs_dir / "new.log"
+    new_log.write_text("new")
+
+    count = cleanup_logs(logs_dir, dry_run=False)
+
+    assert count == 1
+    assert not old_log.exists()
+    assert new_log.exists()
+
+def test_cleanup_backtests(test_env):
+    backtest_dir = test_env["backtest_dir"]
+    archive_dir = test_env["archive_dir"]
+
+    # Create old and new backtest results
+    old_bt = backtest_dir / "old_result.csv"
+    old_bt.write_text("old backtest")
+    old_time = datetime.now() - timedelta(days=RETENTION_BACKTESTS + 1)
+    os.utime(old_bt, (old_time.timestamp(), old_time.timestamp()))
+
+    new_bt = backtest_dir / "new_result.csv"
+    new_bt.write_text("new backtest")
+
+    count = cleanup_backtests(backtest_dir, dry_run=False, archive_dir=archive_dir)
+
+    assert count == 1
+    assert not old_bt.exists()
+    assert new_bt.exists()
+
+    # Check if archive exists
+    archives = list(archive_dir.glob("archive_backtests_*.tar.gz"))
+    assert len(archives) == 1
+    assert Path(str(archives[0]) + ".sha256").exists()
+
+    # Verify archive content
+    with tarfile.open(archives[0], "r:gz") as tar:
+        names = tar.getnames()
+        assert "old_result.csv" in names
+
+def test_cleanup_database_retention(test_env):
+    db_url = test_env["db_url"]
+    audit_db_url = test_env["audit_db_url"]
+    archive_dir = test_env["archive_dir"]
+    TradeSession = test_env["TradeSession"]
+    AuditSession = test_env["AuditSession"]
+
+    now = datetime.now(timezone.utc)
+
+    with TradeSession() as session:
+        # 1. Unlinked Signal (Old) -> Should be purged
+        old_unlinked = ModelSignal(symbol="XAUUSD", direction=1, entry_price=2000.0, created_at=now - timedelta(days=RETENTION_UNLINKED_SIGNALS + 1))
+        # 2. Linked Signal (Old) -> Should be preserved
+        old_linked_signal = ModelSignal(symbol="XAUUSD", direction=1, entry_price=2000.0, created_at=now - timedelta(days=RETENTION_UNLINKED_SIGNALS + 1))
+        session.add_all([old_unlinked, old_linked_signal])
+        session.commit()
+
+        old_linked_signal_id = old_linked_signal.id
+
+        # Trade linked to the old signal (New)
+        new_trade = Trade(ticket=123, symbol="XAUUSD", direction=1, entry_price=2000.0, lot_size=0.1, signal_id=old_linked_signal_id, created_at=now)
+        # Old Trade -> Should be archived and purged
+        old_trade = Trade(ticket=456, symbol="XAUUSD", direction=1, entry_price=1900.0, lot_size=0.1, created_at=now - timedelta(days=RETENTION_TRADES + 1))
+
+        # Old Risk Event -> Should be archived and purged
+        old_risk = RiskEvent(event_type="CIRCUIT_BREAKER", description="test", created_at=now - timedelta(days=RETENTION_RISK_EVENTS + 1))
+
+        # Old Performance Metric -> Should be archived and purged
+        old_perf = PerformanceMetric(sharpe_ratio=1.5, created_at=now - timedelta(days=RETENTION_PERFORMANCE_METRICS + 1))
+
+        session.add_all([new_trade, old_trade, old_risk, old_perf])
+        session.commit()
+
+    with AuditSession() as session:
+        # Old Audit Entry -> Should be archived and purged
+        old_audit = AuditEntry(action="TEST", actor="SYS", created_at=now - timedelta(days=RETENTION_AUDIT_LOG + 1))
+        session.add(old_audit)
+        session.commit()
+
+    # Run Cleanup
+    results = cleanup_database(db_url, audit_db_url=audit_db_url, dry_run=False, archive_dir=archive_dir)
+
+    assert results["model_signals"] == 1 # only the unlinked one
+    assert results["risk_events"] == 1
+    assert results["performance_metrics"] == 1
+    assert results["trades"] == 1
+    assert results["audit_log"] == 1
+
+    # Verify DB state
+    with TradeSession() as session:
+        # Check ModelSignal
+        signals = session.execute(select(ModelSignal)).scalars().all()
+        assert len(signals) == 1
+        assert signals[0].id == old_linked_signal_id
+
+        # Check Trades
+        trades = session.execute(select(Trade)).scalars().all()
+        assert len(trades) == 1
+        assert trades[0].ticket == 123
+
+        # Check RiskEvents
+        risks = session.execute(select(RiskEvent)).scalars().all()
+        assert len(risks) == 0
+
+        # Check Performance Metrics
+        perfs = session.execute(select(PerformanceMetric)).scalars().all()
+        assert len(perfs) == 0
+
+    with AuditSession() as session:
+        audits = session.execute(select(AuditEntry)).scalars().all()
+        assert len(audits) == 0
+
+    # Verify Archives
+    assert len(list(archive_dir.glob("archive_risk_events_*.csv"))) == 1
+    assert len(list(archive_dir.glob("archive_performance_metrics_*.csv"))) == 1
+    assert len(list(archive_dir.glob("archive_trades_*.csv"))) == 1
+    assert len(list(archive_dir.glob("archive_audit_log_*.csv"))) == 1
+    assert len(list(archive_dir.glob("*.sha256"))) >= 4


### PR DESCRIPTION
This PR establishes the enterprise data retention framework for the trading bot. It includes a formal policy document and an automated cleanup script that ensures compliance with 7-year regulatory requirements for trades and audit logs while optimizing storage for ephemeral diagnostics and model signals. 

Key features:
- Archival of database records to CSV with SHA256 checksums.
- Bundling of research/backtest results into compressed .tar.gz archives.
- Safe deletion logic preventing the removal of signals required for trade traceability.
- Robust configuration handling allowing headless execution without active MT5 connectivity.
- Full test coverage for retention boundaries and archival integrity.

---
*PR created automatically by Jules for task [8783790423663310793](https://jules.google.com/task/8783790423663310793) started by @andonly1348*