### PR TITLE
📘 Jules02: Documentation and schema governance — Trading Decision Hardening

### DIFF
--- a/TRADING_STANDARDS.md
+++ b/TRADING_STANDARDS.md
@@ -33,7 +33,7 @@ def calculate_position_size(
 ### 1.3 Stop-Loss & Take-Profit Rules
 - **Minimum Stop Distance**: 10 pips for XAUUSD
 - **Mandatory Stop-Loss**: Every trade must have a hard stop-loss
-- **Risk-Reward Ratio**: Minimum 1:1.5 (1 risked to gain 1.5)
+- **Risk-Reward Ratio**: Minimum 1:1.5 (1 risked to gain 1.5) [ENFORCED IN SCHEMA]
 - **Trailing Stops**: Implement after profit threshold (e.g., +50 pips)
 - **Profit Target Levels**: Multiple profit levels with partial exits
 

--- a/docs/quality/SCHEMA_GOVERNANCE.md
+++ b/docs/quality/SCHEMA_GOVERNANCE.md
@@ -7,13 +7,14 @@ This document outlines the standards for data validation and schema enforcement 
 Trading signals are the most critical data structures in the system. To ensure technical trust and prevent catastrophic failures due to malformed data, `TradeSignal` in `src/core/schemas.py` utilizes Pydantic for strict runtime validation.
 
 ### Enforced Constraints:
-- **Symbol**: Must be a valid financial instrument.
+- **Symbol**: Must be 3-20 uppercase alphanumeric characters (`^[A-Z0-9]{3,20}$`).
 - **Direction**: Strictly limited to `1` (BUY), `-1` (SELL), or `0` (HOLD).
 - **Prices**: Entry, Stop Loss, and Take Profit must be positive floats.
 - **Lot Size**: Minimum size is `0.01` to prevent execution errors.
 - **Confidence**: Must be between `0.0` and `1.0`.
+- **Risk-Reward Ratio**: Minimum 1:1.5 ratio is required for all BUY/SELL signals.
 
-### Price Boundary Validation (Sanity Checks):
+### Price Boundary and Risk Validation:
 To prevent "fat-finger" errors or model malfunctions, the following directional price checks are enforced:
 - **BUY Signals**:
     - `Stop Loss` must be **below** `Entry Price`.
@@ -22,15 +23,24 @@ To prevent "fat-finger" errors or model malfunctions, the following directional 
     - `Stop Loss` must be **above** `Entry Price`.
     - `Take Profit` must be **below** `Entry Price`.
 
-Any signal that violates these boundaries will raise a `ValidationError` and will be blocked before reaching the risk engine or broker.
+Any signal that violates these boundaries or fails the minimum R:R check will raise a `ValidationError` and will be blocked before reaching the risk engine or broker.
 
-## 2. Validation Strategy
+## 2. Decision Support Invariants
+
+To maintain institutional trust, the `DecisionPacket` in `src/core/decision_support.py` enforces logical consistency between decision dimensions:
+1. **Binary Executability**: If `is_executable` is True, there must be ZERO `blocking_reasons`.
+2. **Status Alignment**: If `is_executable` is True, the `status_level` cannot be `BLOCKED`.
+3. **Fail-Safe Integrity**: If `is_executable` is False, the `status_level` cannot be `EXECUTE`.
+
+These invariants prevent operational surprise by ensuring that the automated decision status aligns perfectly with the underlying risk and filter results.
+
+## 3. Validation Strategy
 
 1. **Defensive Creation**: Objects are validated at the point of creation using Pydantic models.
 2. **Standardized Enums**: `SignalDirection` IntEnum ensures consistent direction handling across models and adapters.
 3. **Fail-Fast**: Invalid data triggers a `ValidationError` immediately, preventing malformed signals from propagating through the risk engine.
 4. **Unified Schema**: A single source of truth for `TradeSignal` is maintained in `src/core/schemas.py` and used system-wide.
 
-## 3. Implementation Details
+## 4. Implementation Details
 
 The centralized schema is located at `src/core/schemas.py`. All new models or adapters generating signals MUST utilize this schema to ensure compliance with institutional safety standards.

--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -8,7 +8,12 @@ from enum import Enum, IntEnum
 
 
 class SignalDirection(IntEnum):
-    """Standardized signal directions across all models and environments."""
+    """
+    Standardized signal directions across all models and environments.
+    BUY (1) : Positive price expectation, trigger long entry.
+    SELL (-1): Negative price expectation, trigger short entry.
+    HOLD (0): Neutral or uncertain, do not enter or maintain flat.
+    """
 
     BUY = 1
     SELL = -1
@@ -16,7 +21,12 @@ class SignalDirection(IntEnum):
 
 
 class DecisionStatus(str, Enum):
-    """Augmented status levels for trade execution."""
+    """
+    Augmented status levels for trade execution.
+    EXECUTE: High-confidence signal passing all filters and risk gates.
+    CAUTION: Valid signal but with elevated risk or lower confidence; may require manual oversight or reduced sizing.
+    BLOCKED: Signal rejected by risk management, execution filters, or macro intelligence.
+    """
 
     EXECUTE = "execute"
     CAUTION = "caution"
@@ -48,7 +58,12 @@ class EventCategory(Enum):
 class ModelAction(IntEnum):
     """
     Standardized categorical actions used by RL environments and model outputs.
-    Mapped to SignalDirection in adapters or the execution loop.
+    Mapped to SignalDirection in adapters or the execution loop to ensure
+    consistent interpretation of model predictions.
+
+    HOLD (0): No action recommended.
+    BUY (1) : Long position recommended.
+    SELL (2): Short position recommended.
     """
 
     HOLD = 0

--- a/src/core/decision_support.py
+++ b/src/core/decision_support.py
@@ -13,7 +13,7 @@ import logging
 from datetime import UTC, datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from src.core.constants import DecisionStatus, SignalDirection
 from src.core.explainability import SignalExplainer, SignalExplanation
@@ -24,52 +24,87 @@ logger = logging.getLogger(__name__)
 
 
 class PerformanceContext(BaseModel):
-    """Recent performance metrics for the current strategy/account."""
+    """
+    Recent performance metrics for the current strategy/account.
+    Enables the operator to understand the strategy's current state.
+    """
 
-    sharpe_ratio: float = Field(0.0, description="Recent Sharpe Ratio")
-    profit_factor: float = Field(0.0, description="Recent Profit Factor")
-    recovery_factor: float = Field(0.0, description="Recent Recovery Factor")
-    win_rate: float = Field(0.0, description="Recent win rate percentage")
-    win_loss_ratio: float = Field(0.0, description="Recent Win/Loss Ratio")
-    max_drawdown: float = Field(0.0, description="Maximum drawdown observed")
-    total_trades: int = Field(0, description="Total trades in the analysis window")
+    sharpe_ratio: float = Field(
+        0.0, description="Risk-adjusted return (Sharpe Ratio). Target > 2.0 per standards."
+    )
+    profit_factor: float = Field(
+        0.0, description="Gross Profit / Gross Loss. Target > 2.0 per standards."
+    )
+    recovery_factor: float = Field(
+        0.0, description="Net Profit / Max Drawdown. Target > 2.0 per standards."
+    )
+    win_rate: float = Field(0.0, description="Percentage of winning trades (0.0 to 1.0).")
+    win_loss_ratio: float = Field(0.0, description="Average Win / Average Loss.")
+    max_drawdown: float = Field(
+        0.0, description="Maximum observed equity drawdown from peak to trough."
+    )
+    total_trades: int = Field(0, ge=0, description="Count of trades analyzed in this window.")
 
 
 class DecisionPacket(BaseModel):
     """
     Unified packet for operator review before trade execution.
-    Aggregates all critical dimensions of a trading decision.
+    Aggregates all critical dimensions of a trading decision for institutional trust.
     """
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
-    timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
-    symbol: str = Field(..., description="Target trading symbol")
-    direction: SignalDirection = Field(..., description="Final signal direction")
-    consensus: str = Field(..., description="Qualitative model consensus level")
+    timestamp: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        description="UTC timestamp when the decision was finalized.",
+    )
+    symbol: str = Field(..., description="Target trading symbol (e.g., XAUUSD).")
+    direction: SignalDirection = Field(
+        ..., description="Consolidated signal direction from the ensemble."
+    )
+    consensus: str = Field(..., description="Qualitative consensus level (e.g., 💪 Strong Majority).")
     status_level: DecisionStatus = Field(
-        DecisionStatus.BLOCKED, description="Augmented status level"
+        DecisionStatus.BLOCKED, description="Augmented execution status for operator safety."
     )
     decision_score: float = Field(
-        0.0, ge=0.0, le=100.0, description="Composite decision confidence score"
+        0.0, ge=0.0, le=100.0, description="Composite decision confidence score (0 to 100)."
     )
     sizing_multiplier: float = Field(
-        0.0, ge=0.0, le=1.0, description="Recommended sizing multiplier"
+        0.0, ge=0.0, le=1.0, description="Risk-based sizing multiplier (0.0 to 1.0)."
     )
     is_executable: bool = Field(
-        False, description="Final decision on whether the trade should proceed"
+        False, description="Final binary decision on whether execution is permitted."
     )
     blocking_reasons: list[str] = Field(
-        default_factory=list, description="List of reasons if the trade is blocked"
+        default_factory=list, description="Explicit reasons for blocking the trade, if any."
     )
 
     # Components
     explanation: SignalExplanation = Field(
-        ..., description="ML signal attribution and explainability"
+        ..., description="Detailed signal attribution and machine-learning explainability."
     )
-    regime: RegimeInfo = Field(..., description="Current market regime context")
-    macro_risk: RiskStatus = Field(..., description="Macroeconomic event risk status")
-    performance: PerformanceContext = Field(..., description="Recent performance context")
+    regime: RegimeInfo = Field(..., description="Current market regime and volatility state.")
+    macro_risk: RiskStatus = Field(..., description="Real-time macroeconomic risk intelligence.")
+    performance: PerformanceContext = Field(
+        ..., description="Recent performance metrics providing historical context."
+    )
+
+    @model_validator(mode="after")
+    def validate_executable_state(self) -> DecisionPacket:
+        """
+        Enforce technical trust: a trade cannot be executable if it has blocking reasons
+        or if the status level is BLOCKED.
+        """
+        if self.is_executable:
+            if self.blocking_reasons:
+                raise ValueError("Decision cannot be executable with active blocking reasons.")
+            if self.status_level == DecisionStatus.BLOCKED:
+                raise ValueError("Decision cannot be executable with a BLOCKED status level.")
+        else:
+            # If not executable, ensure consistency with status/reasons for clarity
+            if self.status_level == DecisionStatus.EXECUTE:
+                # Optional: could warn or auto-coerce, but Jules prefers deterministic validation
+                raise ValueError("Status level cannot be EXECUTE if is_executable is False.")
+
+        return self
 
 
 class DecisionSupportSystem:

--- a/src/core/decision_support.py
+++ b/src/core/decision_support.py
@@ -13,7 +13,7 @@ import logging
 from datetime import UTC, datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, Field, model_validator
 
 from src.core.constants import DecisionStatus, SignalDirection
 from src.core.explainability import SignalExplainer, SignalExplanation

--- a/src/core/schemas.py
+++ b/src/core/schemas.py
@@ -25,15 +25,30 @@ class TradeSignal(BaseModel):
     Enforces strict constraints to ensure technical trust in model outputs.
     """
 
-    symbol: str = Field(..., description="The financial instrument symbol (e.g., XAUUSD)")
-    direction: SignalDirection = Field(..., description="Signal direction: 1 (BUY), -1 (SELL), 0 (HOLD)")
-    entry_price: float = Field(..., gt=0, description="The target entry price for the trade")
-    stop_loss: float = Field(..., gt=0, description="The mandatory protective stop loss price")
-    take_profit: float = Field(..., gt=0, description="The target profit taking price")
+    symbol: str = Field(
+        ...,
+        pattern=r"^[A-Z0-9]{3,20}$",
+        description="The financial instrument symbol (e.g., XAUUSD). Must be 3-20 uppercase alphanumeric characters.",
+    )
+    direction: SignalDirection = Field(
+        ..., description="Signal direction: 1 (BUY), -1 (SELL), 0 (HOLD)"
+    )
+    entry_price: float = Field(
+        ..., gt=0, description="The target entry price for the trade (must be positive)"
+    )
+    stop_loss: float = Field(
+        ..., gt=0, description="The mandatory protective stop loss price (must be positive)"
+    )
+    take_profit: float = Field(
+        ..., gt=0, description="The target profit taking price (must be positive)"
+    )
     lot_size: float = Field(..., ge=0.01, description="The position size in lots (minimum 0.01)")
     algorithm: str = Field(..., description="The name of the algorithm that generated this signal")
     confidence: float = Field(
-        ..., ge=0.0, le=1.0, description="The model's confidence score (0.0 to 1.0)"
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="The model's confidence score (0.0 to 1.0). Higher means more certainty.",
     )
     timestamp: datetime = Field(
         default_factory=lambda: datetime.now(UTC),
@@ -55,8 +70,26 @@ class TradeSignal(BaseModel):
     def validate_price_boundaries(self) -> TradeSignal:
         """
         Validate that SL/TP are on the correct side of the entry price
-        based on the signal direction.
+        based on the signal direction and enforce minimum Risk-Reward ratio.
         """
+        if self.direction == SignalDirection.HOLD:
+            return self
+
+        risk = abs(self.entry_price - self.stop_loss)
+        reward = abs(self.take_profit - self.entry_price)
+
+        if risk <= 0:
+            raise ValueError("Risk (Entry - SL) must be greater than zero")
+
+        rr_ratio = reward / risk
+        min_rr = 1.5
+
+        if rr_ratio < min_rr:
+            raise ValueError(
+                f"Risk-Reward ratio ({rr_ratio:.2f}) is below the required minimum of {min_rr}. "
+                f"Risk: {risk:.2f}, Reward: {reward:.2f}"
+            )
+
         if self.direction == SignalDirection.BUY:
             if self.stop_loss >= self.entry_price:
                 raise ValueError(

--- a/tests/test_decision_support_validation.py
+++ b/tests/test_decision_support_validation.py
@@ -1,0 +1,110 @@
+
+import pytest
+from datetime import datetime, UTC
+from pydantic import ValidationError
+from src.core.decision_support import DecisionPacket, PerformanceContext
+from src.core.constants import DecisionStatus, SignalDirection
+from src.core.explainability import SignalExplanation, ExecutionSummary, RiskAssessment, RegimeContext
+from src.data.event_intelligence import RiskStatus
+from src.models.regime_detector import RegimeInfo, MarketRegime
+
+@pytest.fixture
+def valid_components():
+    explanation = SignalExplanation(
+        symbol="XAUUSD",
+        direction=SignalDirection.BUY,
+        total_confidence=0.8,
+        execution_summary=ExecutionSummary(passed=True, summary="All passed"),
+        model_attributions=[],
+        feature_contributions=[],
+        risk_assessment=RiskAssessment(passed=True, risk_reward_ratio=2.0, summary="Good"),
+        regime_context=RegimeContext(regime_name="Trending", confidence=0.9),
+        human_readable_summary="Test",
+        machine_attribution={}
+    )
+    regime = RegimeInfo(label=MarketRegime.TRENDING, confidence=0.9, transition_score=0.1, volatility_index=1.0)
+    macro_risk = RiskStatus(is_blocked=False, risk_multiplier=1.0)
+    performance = PerformanceContext(total_trades=10)
+    return {
+        "explanation": explanation,
+        "regime": regime,
+        "macro_risk": macro_risk,
+        "performance": performance
+    }
+
+def test_decision_packet_valid_execute(valid_components):
+    """Verify that a valid executable packet passes validation."""
+    packet = DecisionPacket(
+        symbol="XAUUSD",
+        direction=SignalDirection.BUY,
+        consensus="Strong",
+        status_level=DecisionStatus.EXECUTE,
+        decision_score=85.0,
+        sizing_multiplier=1.0,
+        is_executable=True,
+        blocking_reasons=[],
+        **valid_components
+    )
+    assert packet.is_executable is True
+    assert not packet.blocking_reasons
+
+def test_decision_packet_valid_blocked(valid_components):
+    """Verify that a valid blocked packet passes validation."""
+    packet = DecisionPacket(
+        symbol="XAUUSD",
+        direction=SignalDirection.BUY,
+        consensus="Weak",
+        status_level=DecisionStatus.BLOCKED,
+        decision_score=40.0,
+        sizing_multiplier=0.0,
+        is_executable=False,
+        blocking_reasons=["Risk too high"],
+        **valid_components
+    )
+    assert packet.is_executable is False
+    assert "Risk too high" in packet.blocking_reasons
+
+def test_decision_packet_invalid_executable_with_reasons(valid_components):
+    """Verify that an executable packet cannot have blocking reasons."""
+    with pytest.raises(ValidationError, match="cannot be executable with active blocking reasons"):
+        DecisionPacket(
+            symbol="XAUUSD",
+            direction=SignalDirection.BUY,
+            consensus="Strong",
+            status_level=DecisionStatus.EXECUTE,
+            decision_score=85.0,
+            sizing_multiplier=1.0,
+            is_executable=True,
+            blocking_reasons=["Something is wrong"],
+            **valid_components
+        )
+
+def test_decision_packet_invalid_executable_with_blocked_status(valid_components):
+    """Verify that an executable packet cannot have BLOCKED status."""
+    with pytest.raises(ValidationError, match="cannot be executable with a BLOCKED status level"):
+        DecisionPacket(
+            symbol="XAUUSD",
+            direction=SignalDirection.BUY,
+            consensus="Strong",
+            status_level=DecisionStatus.BLOCKED,
+            decision_score=85.0,
+            sizing_multiplier=1.0,
+            is_executable=True,
+            blocking_reasons=[],
+            **valid_components
+        )
+
+def test_decision_packet_invalid_non_executable_with_execute_status(valid_components):
+    """Verify that a non-executable packet cannot have EXECUTE status."""
+    with pytest.raises(ValidationError, match="Status level cannot be EXECUTE if is_executable is False"):
+        DecisionPacket(
+            symbol="XAUUSD",
+            direction=SignalDirection.BUY,
+            consensus="Strong",
+            status_level=DecisionStatus.EXECUTE,
+            decision_score=85.0,
+            sizing_multiplier=1.0,
+            is_executable=False,
+            blocking_reasons=["Macro block"],
+            **valid_components
+        )

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -43,6 +43,9 @@ def test_trade_signal_schema_enum_parsing():
     ("lot_size", 0.005),
     ("confidence", -0.1),
     ("confidence", 1.1),
+    ("symbol", "X"),
+    ("symbol", "XAUUSD!"),
+    ("symbol", "this_is_too_long_for_the_schema"),
 ])
 def test_trade_signal_schema_invalid_values(field, value):
     """Verify that invalid values raise ValidationError."""
@@ -61,37 +64,55 @@ def test_trade_signal_schema_invalid_values(field, value):
         TradeSignal(**data)
 
 def test_buy_price_boundaries():
-    """Verify BUY boundary validation (SL < Entry < TP)."""
+    """Verify BUY boundary validation (SL < Entry < TP) and R:R."""
     base = {
         "symbol": "XAUUSD", "direction": 1, "entry_price": 2000.0,
         "lot_size": 0.1, "algorithm": "test", "confidence": 0.9
     }
 
-    # Valid
-    TradeSignal(**base, stop_loss=1900, take_profit=2100)
+    # Valid (Reward=300, Risk=100, RR=3.0)
+    TradeSignal(**base, stop_loss=1900, take_profit=2300)
+
+    # Invalid R:R (Reward=50, Risk=100, RR=0.5)
+    with pytest.raises(ValidationError, match="Risk-Reward ratio"):
+        TradeSignal(**base, stop_loss=1900, take_profit=2050)
 
     # Invalid SL
     with pytest.raises(ValidationError, match="BUY Stop Loss"):
-        TradeSignal(**base, stop_loss=2050, take_profit=2100)
+        TradeSignal(**base, stop_loss=2050, take_profit=2300)
 
-    # Invalid TP
+    # Invalid TP (Higher than entry, but RR < 1.5)
+    with pytest.raises(ValidationError, match="Risk-Reward ratio"):
+        TradeSignal(**base, stop_loss=1900, take_profit=2050)
+
+    # Invalid TP (Lower than entry, but RR is valid)
+    # Risk = 100, Reward = 200 (RR=2.0)
     with pytest.raises(ValidationError, match="BUY Take Profit"):
-        TradeSignal(**base, stop_loss=1900, take_profit=1950)
+        TradeSignal(**base, stop_loss=1900, take_profit=1800)
 
 def test_sell_price_boundaries():
-    """Verify SELL boundary validation (SL > Entry > TP)."""
+    """Verify SELL boundary validation (SL > Entry > TP) and R:R."""
     base = {
         "symbol": "XAUUSD", "direction": -1, "entry_price": 2000.0,
         "lot_size": 0.1, "algorithm": "test", "confidence": 0.9
     }
 
-    # Valid
-    TradeSignal(**base, stop_loss=2100, take_profit=1900)
+    # Valid (Reward=300, Risk=100, RR=3.0)
+    TradeSignal(**base, stop_loss=2100, take_profit=1700)
+
+    # Invalid R:R (Reward=50, Risk=100, RR=0.5)
+    with pytest.raises(ValidationError, match="Risk-Reward ratio"):
+        TradeSignal(**base, stop_loss=2100, take_profit=1950)
 
     # Invalid SL
     with pytest.raises(ValidationError, match="SELL Stop Loss"):
-        TradeSignal(**base, stop_loss=1950, take_profit=1900)
+        TradeSignal(**base, stop_loss=1950, take_profit=1700)
 
-    # Invalid TP
+    # Invalid TP (Lower than entry, but RR < 1.5)
+    with pytest.raises(ValidationError, match="Risk-Reward ratio"):
+        TradeSignal(**base, stop_loss=2100, take_profit=1950)
+
+    # Invalid TP (Higher than entry, but RR is valid)
+    # Risk = 100, Reward = 200 (RR=2.0)
     with pytest.raises(ValidationError, match="SELL Take Profit"):
-        TradeSignal(**base, stop_loss=2100, take_profit=2050)
+        TradeSignal(**base, stop_loss=2100, take_profit=2200)


### PR DESCRIPTION
### Documentation and Schema Governance Hardening

This PR strengthens the technical trust and operational clarity of the trading decision pipeline by enforcing stricter schemas and improving technical documentation.

#### Changes:
- **`src/core/schemas.py`**:
    - Enhanced `TradeSignal` with regex pattern validation for symbols (`^[A-Z0-9]{3,20}$`).
    - Added a mandatory minimum **Risk-Reward (RR) ratio of 1.5** for all executable signals, aligning with institutional standards.
    - Improved field descriptions for auto-generated documentation.
- **`src/core/decision_support.py`**:
    - Implemented a `model_validator` in `DecisionPacket` to ensure that a trade cannot be marked as `is_executable` if there are active `blocking_reasons` or if the `status_level` is `BLOCKED`.
    - Added high-fidelity documentation to all fields in `DecisionPacket` and `PerformanceContext` to improve operator clarity during manual reviews.
    - Cleaned up `model_config` as all nested types are now confirmed Pydantic models.
- **`src/core/constants.py`**:
    - Added detailed docstrings to `SignalDirection`, `DecisionStatus`, and `ModelAction` explaining their role in the system and how they map between ML model outputs and execution commands.
- **Testing**:
    - Updated `tests/test_schemas.py` to verify RR ratio and symbol validation.
    - Created `tests/test_decision_support_validation.py` to ensure invariant enforcement in the decision pipeline.

#### Validation:
- Ran 56 tests (all passed), including new validation scenarios.
- Verified schema consistency via `ruff` and `mypy`.
- Performed a self-correction on a minor indentation nitpick identified during code review.

#### Out of Scope:
- Modifying the actual model inference logic (focused strictly on validation and documentation).
- Changing database schema (relying on existing VARCHAR(20) constraints).

#### Follow-up Recommendation:
- Consider making the 1.5 RR ratio configurable in `TradingConfig` in a future iteration, though currently it is enforced as a hard floor for technical trust.

---
*PR created automatically by Jules for task [14613576450812404772](https://jules.google.com/task/14613576450812404772) started by @xnessom*