### PR TITLE
docs: update daily merge-readiness checklist [2026-05-07]

### DIFF
--- a/docs/status/MERGE_READY_CHECKLIST.md
+++ b/docs/status/MERGE_READY_CHECKLIST.md
@@ -1,35 +1,47 @@
 # Merge-Readiness Checklist
 
 > [!IMPORTANT]
-> **Critical Repository State Notice:** The `main` branch is currently operating under a history-grafting model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules.
+> **Critical Repository State Notice:** The `main` branch is currently operating under a history-grafting model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **All current PRs are functionally stale and require a fresh rebase onto the latest baseline (`cec9dce`).**
 
-Generated on: 2026-05-07 13:37:10 UTC
+Generated on: 2026-05-07 14:35:00 UTC
 
 This checklist identifies top promising PRs for immediate review.
 
 ## 1. PR #778: Implement Enterprise Disaster Recovery Plan and Automated Backup Verification
-- **Scope**: Safe Surface update
-- **Status**: Ready for detailed review (CI: pending)
+- **Author**: andonly1348
+- **Commit**: c335c93
+- **Scope**: Disaster recovery framework (`docs/DISASTER_RECOVERY.md`) and automated backup scripts (`scripts/backup_verify.sh`).
 - **Risk**: Safe Surface
-- **Why**: Only documentation, tests, or non-critical configurations.
-- **Missing Items**: None identified from triage heuristics.
-- **Recommendation**: Jules05 or human review candidate.
+- **Status**: ⚠️ **Stale** - Requires rebase.
+- **Why**: Touches documentation and utility scripts only.
+- **Recommendation**: Candidate for review after rebase.
 
 ## 2. PR #792: 🧬 Jules02: Synthetic test scenarios — Full-Cascade Safety & Data Quality
-- **Scope**: Medium Risk update
-- **Status**: Ready for detailed review (CI: pending)
+- **Author**: xnessom
+- **Commit**: 1e0f299
+- **Scope**: Enhancements to `ScenarioGenerator` and `ExecutionScenarioBuilder` for safety cascade verification.
 - **Risk**: Medium Risk
-- **Why**: Touches core/research/analytics/risk: src/core/config_validator.py
-- **Missing Items**: None identified from triage heuristics.
-- **Recommendation**: Jules05 or human review candidate.
+- **Status**: ⚠️ **Stale** - Requires rebase.
+- **Why**: Touches core test infrastructure and configuration validation logic.
+- **Recommendation**: High priority for Jules05 review once rebased.
 
-## 3. PR #740: Enhance RareEventSimulator for Institutional Black-Swan Research
-- **Scope**: Medium Risk update
-- **Status**: Ready for detailed review (CI: pending)
+## 3. PR #712: 🗺️ Atlas: Startup Validation Layer
+- **Author**: andonly1348
+- **Commit**: 5cf8e76
+- **Scope**: Robust startup checks for MT5 credentials, symbols, and environment safety.
 - **Risk**: Medium Risk
-- **Why**: Touches core/research/analytics/risk: src/research/rare_event_simulator.py
-- **Missing Items**: None identified from triage heuristics.
-- **Recommendation**: Jules05 or human review candidate.
+- **Status**: ⚠️ **Stale** - Requires rebase.
+- **Why**: Adds a critical safety layer for production entrypoints.
+- **Recommendation**: Candidate for review after rebase.
+
+## 4. PR #740: Enhance RareEventSimulator for Institutional Black-Swan Research
+- **Author**: saysgrok
+- **Commit**: ac40015
+- **Scope**: Standardization of metrics and addition of market stress features (spread widening, volume surges).
+- **Risk**: Medium Risk
+- **Status**: ⚠️ **Stale** - Requires rebase.
+- **Why**: Touches research models and verification scripts.
+- **Recommendation**: Candidate for review after rebase.
 
 ---
 *Prepared by Jules06 (qufuwan) for Jules05 and human review.*


### PR DESCRIPTION
This PR updates the daily merge-readiness checklist for May 7th, 2026. It identifies promising candidates for review (PRs #778, #792, #712, and #740) while explicitly highlighting the critical need for rebasing due to the repository's history-grafting state.

---
*PR created automatically by Jules for task [11717436399804524728](https://jules.google.com/task/11717436399804524728) started by @triqbit*