### PR TITLE
Refine institutional trade signal explainability

### DIFF
--- a/docs/features/EXPLAINABILITY.md
+++ b/docs/features/EXPLAINABILITY.md
@@ -29,7 +29,7 @@ Attributes decisions to specific feature clusters.
 Provides the environmental background for the signal.
 - **Detected Regime**: (e.g., Trending, Ranging, News Shock).
 - **Regime Confidence**: Reliability of the regime classification.
-- **Favorable Check**: Whether the strategy is optimized for the current state.
+- **Favorable Check**: Explicitly flags whether the strategy is optimized for the current state (e.g., "Market state is considered favorable" vs "Market state is UNFAVORABLE/CAUTIONARY").
 
 ### 5. Risk Assessment
 The final gate where signals are validated against institutional risk constraints.
@@ -65,7 +65,9 @@ explanation = explainer.explain(
     risk_data={"passed": True, "risk_reward": 2.5, "summary": "Risk within limits"},
     regime_info=regime,
     # Supports automated feature clustering from raw scores
-    feature_impacts={"base_M5_rsi": 0.8, "base_M5_slope": 0.7}
+    feature_impacts={"base_M5_rsi": 0.8, "base_M5_slope": 0.7},
+    # Pass optional signal_id for end-to-end traceability
+    signal_id=42
 )
 ```
 

--- a/src/core/explainability.py
+++ b/src/core/explainability.py
@@ -158,6 +158,7 @@ class SignalExplainer:
         execution_data: dict[str, Any] | ExecutionDecision | None = None,
         feature_impacts: list[dict[str, Any]] | dict[str, float] | None = None,
         model_confidences: dict[str, float] | None = None,
+        signal_id: int | None = None,
     ) -> SignalExplanation:
         """
         Generate a comprehensive explanation for a trade signal.
@@ -338,6 +339,10 @@ class SignalExplainer:
         if dominant_models:
             reasoning += f"Primary driver(s): {', '.join(dominant_models)}. "
         reasoning += f"Market is currently in a {regime_context.regime_name} regime. "
+        if regime_context.is_favorable:
+            reasoning += "Market state is considered favorable for this strategy. "
+        else:
+            reasoning += "Market state is UNFAVORABLE/CAUTIONARY for this strategy. "
 
         # Add key feature impacts if available
         high_impact_features = [c for c in contributions if c.impact_level == "High"]
@@ -368,6 +373,7 @@ class SignalExplainer:
         }
 
         return SignalExplanation(
+            signal_id=signal_id,
             symbol=symbol,
             direction=SignalDirection(direction),
             total_confidence=confidence,

--- a/src/core/explainability.py
+++ b/src/core/explainability.py
@@ -174,6 +174,7 @@ class SignalExplainer:
             execution_data: Optional execution filter data or ExecutionDecision object.
             feature_impacts: Optional list of cluster impacts or dict of individual feature scores.
             model_confidences: Optional dictionary mapping model names to their individual confidence scores.
+            signal_id: Optional database ID of the signal for traceability.
 
         Returns:
             A structured SignalExplanation object.

--- a/tests/test_explainability.py
+++ b/tests/test_explainability.py
@@ -464,3 +464,51 @@ def test_signal_explainer_mixed_votes():
     assert lstm_attr.confidence == 0.5
     assert ppo_attr.is_dominant is True
     assert lstm_attr.is_dominant is False
+
+
+def test_signal_explainer_with_signal_id():
+    """Test that SignalExplainer correctly handles and passes through signal_id."""
+    explainer = SignalExplainer()
+    signal_id = 12345
+
+    explanation = explainer.explain(
+        symbol="XAUUSD",
+        direction=1,
+        confidence=0.9,
+        model_votes={"ppo": 1},
+        model_weights={"ppo": 1.0},
+        risk_data={"passed": True},
+        regime_info={"name": "Trending"},
+        signal_id=signal_id,
+    )
+
+    assert explanation.signal_id == signal_id
+
+
+def test_signal_explainer_summary_regime_favorability():
+    """Test that the summary explicitly mentions market favorability."""
+    explainer = SignalExplainer()
+
+    # Case 1: Favorable Regime
+    exp_favorable = explainer.explain(
+        symbol="XAUUSD",
+        direction=1,
+        confidence=0.8,
+        model_votes={"ppo": 1},
+        model_weights={"ppo": 1.0},
+        risk_data={"passed": True},
+        regime_info={"name": "Trending", "is_favorable": True},
+    )
+    assert "Market state is considered favorable for this strategy" in exp_favorable.human_readable_summary
+
+    # Case 2: Unfavorable Regime
+    exp_unfavorable = explainer.explain(
+        symbol="XAUUSD",
+        direction=-1,
+        confidence=0.6,
+        model_votes={"ppo": 2},
+        model_weights={"ppo": 1.0},
+        risk_data={"passed": True},
+        regime_info={"name": "Volatile", "is_favorable": False},
+    )
+    assert "Market state is UNFAVORABLE/CAUTIONARY for this strategy" in exp_unfavorable.human_readable_summary


### PR DESCRIPTION
Refined the trade signal explainability system to meet institutional standards. Key changes include:
- Added `signal_id` support to the `SignalExplainer.explain` method for end-to-end traceability from the database to attribution logs.
- Improved natural language generation for the `human_readable_summary`, providing operators with explicit context on whether the current market regime is favorable or cautionary for the strategy.
- Verified all 16 unit tests pass, ensuring robustness and backward compatibility.

---
*PR created automatically by Jules for task [9151512183444800057](https://jules.google.com/task/9151512183444800057) started by @saysgrok*