### PR TITLE
feat: 🔐 Jules02: Security hardening — enforce weights_only=True in torch.load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Release Readiness Auditing:** Integrated `scripts/check_release_notes.py` to mandate descriptive changelog entries for all new releases.
 
 ### Security
-- No security changes in this section.
+- **Safe PyTorch Deserialization:** Enforced `weights_only=True` in all `torch.load` calls across the codebase (including `main.py` and `src/models/lstm_model.py`) to prevent arbitrary code execution (RCE) from untrusted model files.
+- **Security Regression Guard:** Introduced a static analysis test to ensure any future PyTorch model loading points adhere to the `weights_only` security standard.
 
 ### Deprecated
 - No deprecated items in this section.

--- a/main.py
+++ b/main.py
@@ -1059,7 +1059,7 @@ def main() -> int:
         # Standard input_dim is 140 for the current feature engineer
         model = TimeSeriesTransformer(input_dim=140)
         if torch and transformer_path.exists():
-            model.load_state_dict(torch.load(transformer_path, map_location="cpu"))
+            model.load_state_dict(torch.load(transformer_path, map_location="cpu", weights_only=True))
     else:
         # This branch should rarely be hit if Literal choices are enforced by Pydantic
         log.warning(

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -139,3 +139,55 @@ def test_config_validator_file_permissions(tmp_path, monkeypatch):
     permission_errors = [e for e in result.errors if e.field == "FILE_PERMISSION"]
     assert len(permission_errors) > 0
     assert "Insecure permissions" in permission_errors[0].message
+
+def test_safe_pytorch_loading():
+    """
+    Statically analyze the codebase to ensure all torch.load calls
+    include the weights_only=True argument for security.
+    """
+    import ast
+
+    root_dir = Path(__file__).resolve().parents[1]
+    violations = []
+
+    for path in root_dir.rglob("*.py"):
+        if ".git" in str(path) or "venv" in str(path) or "tests" in str(path):
+            continue
+
+        with open(path, "r", encoding="utf-8") as f:
+            try:
+                tree = ast.parse(f.read())
+            except SyntaxError:
+                continue
+
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Call):
+                    # Check for torch.load(...)
+                    is_torch_load = False
+                    if isinstance(node.func, ast.Attribute):
+                        if (isinstance(node.func.value, ast.Name) and
+                            node.func.value.id == "torch" and
+                            node.func.attr == "load"):
+                            is_torch_load = True
+                    elif isinstance(node.func, ast.Name) and node.func.id == "load":
+                        # Could be 'from torch import load'
+                        # For simplicity, we check if weights_only is present if it looks like a load call
+                        # but we prioritize torch.load
+                        pass
+
+                    if is_torch_load:
+                        has_weights_only = False
+                        for keyword in node.keywords:
+                            if keyword.arg == "weights_only":
+                                if (isinstance(keyword.value, ast.Constant) and
+                                    keyword.value.value is True):
+                                    has_weights_only = True
+                                elif (isinstance(keyword.value, ast.NameConstant) and
+                                      keyword.value.value is True):
+                                    # For older python versions
+                                    has_weights_only = True
+
+                        if not has_weights_only:
+                            violations.append(f"{path.relative_to(root_dir)}:{node.lineno}")
+
+    assert not violations, f"Unsafe torch.load calls found in: {violations}. Always use weights_only=True."


### PR DESCRIPTION
This PR implements a critical security hardening for the trading bot by enforcing `weights_only=True` in all `torch.load` calls. This mitigates the risk of arbitrary code execution (RCE) via malicious PyTorch model files (which use `pickle` for serialization).

Key changes:
1.  **Hardened `main.py`**: Added `weights_only=True` to the loading logic for the `TimeSeriesTransformer` model.
2.  **Security Regression Test**: Introduced `test_safe_pytorch_loading` in `tests/test_security_hardening.py`. This test uses static code analysis (`ast` module) to scan the entire codebase and verify that every `torch.load` call explicitly uses the `weights_only=True` safeguard.

This change ensures that model loading is restricted to safe types (tensors, basic Python collections) and prevents a major class of deserialization vulnerabilities.

---
*PR created automatically by Jules for task [9737333560691806561](https://jules.google.com/task/9737333560691806561) started by @xnessom*