### PR TITLE
Enterprise Data Retention Policy and Automated Cleanup v1.4.0

### DIFF
--- a/docs/DATA_RETENTION_POLICY.md
+++ b/docs/DATA_RETENTION_POLICY.md
@@ -8,10 +8,12 @@ This policy defines the retention periods and disposal procedures for operationa
 | Data Category | Data Type | Retention Period | Disposal Method | Reason |
 |---------------|-----------|------------------|-----------------|--------|
 | **Compliance** | Trade Records (`trades` table) | 7 Years | Archival + Purge | Regulatory Requirement |
+| **Compliance** | Execution Quality (`execution_qualities`) | 7 Years | Archival + Purge | Execution Analytics |
 | **Audit** | Audit Log (`audit_log` table) | 7 Years | Archival + Purge | Enterprise Traceability |
-| **Audit** | Risk Events (`risk_events` table) | 2 Years | Purge | Operational Auditing |
+| **Audit** | Risk Events (`risk_events` table) | 2 Years | Archival + Purge | Operational Auditing |
 | **Audit** | Linked Model Signals | 7 Years | Archival + Purge | Trade Traceability |
 | **Operational** | Unlinked Model Signals | 90 Days | Purge | Performance Tuning |
+| **Operational** | Blocked Signal Analysis | 90 Days | Purge | Opportunity Cost |
 | **Operational** | Performance Metrics | 2 Years | Archival + Purge | Trend Analysis |
 | **Diagnostics** | Application Logs (`logs/*.log`) | 90 Days | Deletion | Troubleshooting |
 | **Research** | Backtest Results | 1 Year | Archival + Deletion | Optimization |
@@ -21,6 +23,7 @@ This policy defines the retention periods and disposal procedures for operationa
 ### 3.1 Audit-Critical Data (Preserve)
 The following data must be preserved for the full 7-year compliance window:
 - **Trade Records**: All fields in the `trades` table, including tickets, symbols, prices, and PnL.
+- **Execution Quality**: High-precision execution analytics linked to each trade record.
 - **Audit Log**: System actions, configuration changes, and operator events in the `audit_log` table.
 - **Linked Signals**: Any `model_signals` record referenced by a `trade` record via `signal_id` OR a `risk_event` record via `signal_id`.
 
@@ -28,6 +31,8 @@ The following data must be preserved for the full 7-year compliance window:
 To maintain referential integrity and auditability:
 - A `model_signals` record is considered "Linked" if it is associated with at least one `trade` or `risk_event`.
 - Linked signals inherit the maximum retention period of their associated records (e.g., 7 years if linked to a trade).
+- `ExecutionQuality` records are linked to `Trade` and inherit its 7-year retention.
+- `BlockedSignalAnalysis` records are linked to `ModelSignal` and inherit the signal's retention (typically 90 days unless linked to a risk event).
 - When a parent record (Trade/RiskEvent) is purged, the cleanup script must verify if the associated signal is still required by another active record before deletion.
 
 ### 3.3 Ephemeral Data (Rotate/Purge)
@@ -60,6 +65,6 @@ The automated cleanup script (`scripts/data_cleanup.py`) should be executed on a
 The primary mechanism for enforcement is the `scripts/data_cleanup.py` tool. It uses the `database_url` and `logs_dir` from the system configuration to target the correct data stores.
 
 ---
-**Version**: 1.3.1
-**Effective Date**: 2026-05-24
+**Version**: 1.4.0
+**Effective Date**: 2024-05-22
 **Owner**: Release Reliability & Governance (Jules03)

--- a/scripts/data_cleanup.py
+++ b/scripts/data_cleanup.py
@@ -24,7 +24,14 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from src.core.audit_log import AuditEntry, AuditLogger
 from src.core.config import get_config
-from src.core.trade_logger import ModelSignal, PerformanceMetric, RiskEvent, Trade
+from src.core.trade_logger import (
+    BlockedSignalAnalysis,
+    ExecutionQuality,
+    ModelSignal,
+    PerformanceMetric,
+    RiskEvent,
+    Trade,
+)
 
 # -- Setup Logging ---------------------------------------------------------
 logging.basicConfig(
@@ -212,11 +219,14 @@ def cleanup_backtests(backtest_dir: Path, dry_run: bool = False, archive_dir: Pa
     return count
 
 
-def cleanup_database(db_url: str, audit_db_url: str = None, dry_run: bool = False, archive_dir: Path = ARCHIVE_DIR) -> dict:
+def cleanup_database(
+    db_url: str, audit_db_url: str = None, dry_run: bool = False, archive_dir: Path = ARCHIVE_DIR
+) -> dict:
     """Purge old records from the database according to the retention policy."""
     engine = create_engine(db_url)
     # Ensure tables exist (especially for SQLite)
     from src.core.trade_logger import Base as TradeBase
+
     TradeBase.metadata.create_all(engine)
 
     Session = sessionmaker(bind=engine)
@@ -225,6 +235,8 @@ def cleanup_database(db_url: str, audit_db_url: str = None, dry_run: bool = Fals
         "risk_events": 0,
         "performance_metrics": 0,
         "trades": 0,
+        "execution_qualities": 0,
+        "blocked_signal_analysis": 0,
         "audit_log": 0,
     }
 
@@ -238,14 +250,22 @@ def cleanup_database(db_url: str, audit_db_url: str = None, dry_run: bool = Fals
         results["risk_events"] = len(risk_records)
 
         if risk_records:
-            logger.info(f"{'[DRY RUN] ' if dry_run else ''}Purging {len(risk_records)} risk events older than {risk_cutoff.date()}")
+            logger.info(
+                f"{'[DRY RUN] ' if dry_run else ''}Purging {len(risk_records)} risk events older than {risk_cutoff.date()}"
+            )
             if not dry_run:
                 # Archiving risk events (Audit 2-year category, archived before purge)
                 if archive_records(risk_records, "risk_events", archive_dir):
                     # Also archive associated signals before deleting risk events
                     signal_ids = {r.signal_id for r in risk_records if r.signal_id}
                     if signal_ids:
-                        signals_to_archive = session.execute(select(ModelSignal).where(ModelSignal.id.in_(signal_ids))).scalars().all()
+                        signals_to_archive = (
+                            session.execute(
+                                select(ModelSignal).where(ModelSignal.id.in_(signal_ids))
+                            )
+                            .scalars()
+                            .all()
+                        )
                         archive_records(signals_to_archive, "linked_risk_signals", archive_dir)
 
                     # Bulk delete
@@ -254,40 +274,72 @@ def cleanup_database(db_url: str, audit_db_url: str = None, dry_run: bool = Fals
                 else:
                     logger.error("Skipping deletion of risk events due to archival failure.")
 
-        # 3. Cleanup Performance Metrics (older than 2 years)
+        # 2. Cleanup Performance Metrics (older than 2 years)
         perf_cutoff = now - timedelta(days=RETENTION_PERFORMANCE_METRICS)
         perf_query = select(PerformanceMetric).where(PerformanceMetric.created_at < perf_cutoff)
         perf_records = session.execute(perf_query).scalars().all()
         results["performance_metrics"] = len(perf_records)
 
         if perf_records:
-            logger.info(f"{'[DRY RUN] ' if dry_run else ''}Purging {len(perf_records)} performance metrics older than {perf_cutoff.date()}")
+            logger.info(
+                f"{'[DRY RUN] ' if dry_run else ''}Purging {len(perf_records)} performance metrics older than {perf_cutoff.date()}"
+            )
             if not dry_run:
                 # Archiving performance metrics (Operational 2-year category, archived before purge)
                 if archive_records(perf_records, "performance_metrics", archive_dir):
                     ids_to_delete = [p.id for p in perf_records]
-                    session.execute(delete(PerformanceMetric).where(PerformanceMetric.id.in_(ids_to_delete)))
+                    session.execute(
+                        delete(PerformanceMetric).where(PerformanceMetric.id.in_(ids_to_delete))
+                    )
                 else:
                     logger.error("Skipping deletion of performance metrics due to archival failure.")
 
-        # 4. Cleanup Trades (older than 7 years)
+        # 3. Cleanup Trades (older than 7 years)
         trade_cutoff = now - timedelta(days=RETENTION_TRADES)
         trade_query = select(Trade).where(Trade.created_at < trade_cutoff)
         trade_records = session.execute(trade_query).scalars().all()
         results["trades"] = len(trade_records)
 
         if trade_records:
-            logger.info(f"{'[DRY RUN] ' if dry_run else ''}Purging {len(trade_records)} trade records older than {trade_cutoff.date()}")
+            logger.info(
+                f"{'[DRY RUN] ' if dry_run else ''}Purging {len(trade_records)} trade records older than {trade_cutoff.date()}"
+            )
             if not dry_run:
                 # Mandatory archival for Compliance data
                 if archive_records(trade_records, "trades", archive_dir):
+                    ids_to_delete = [t.id for t in trade_records]
+
+                    # Also archive and delete associated execution quality records
+                    eq_records = (
+                        session.execute(
+                            select(ExecutionQuality).where(
+                                ExecutionQuality.trade_id.in_(ids_to_delete)
+                            )
+                        )
+                        .scalars()
+                        .all()
+                    )
+                    if eq_records:
+                        archive_records(eq_records, "execution_qualities", archive_dir)
+                        results["execution_qualities"] = len(eq_records)
+                        session.execute(
+                            delete(ExecutionQuality).where(
+                                ExecutionQuality.trade_id.in_(ids_to_delete)
+                            )
+                        )
+
                     # Also archive associated signals before deleting trades
                     signal_ids = {t.signal_id for t in trade_records if t.signal_id}
                     if signal_ids:
-                        signals_to_archive = session.execute(select(ModelSignal).where(ModelSignal.id.in_(signal_ids))).scalars().all()
+                        signals_to_archive = (
+                            session.execute(
+                                select(ModelSignal).where(ModelSignal.id.in_(signal_ids))
+                            )
+                            .scalars()
+                            .all()
+                        )
                         archive_records(signals_to_archive, "linked_signals", archive_dir)
 
-                    ids_to_delete = [t.id for t in trade_records]
                     session.execute(delete(Trade).where(Trade.id.in_(ids_to_delete)))
                 else:
                     logger.error("Skipping deletion of trades due to archival failure.")
@@ -298,8 +350,12 @@ def cleanup_database(db_url: str, audit_db_url: str = None, dry_run: bool = Fals
 
         # Subqueries for linked signals that are NOT being deleted
         # A signal is "kept" if it's linked to a Trade or RiskEvent that is NOT in the deletion list
-        kept_trade_signals = select(Trade.signal_id).where(Trade.signal_id.is_not(None), Trade.created_at >= trade_cutoff)
-        kept_risk_signals = select(RiskEvent.signal_id).where(RiskEvent.signal_id.is_not(None), RiskEvent.created_at >= risk_cutoff)
+        kept_trade_signals = select(Trade.signal_id).where(
+            Trade.signal_id.is_not(None), Trade.created_at >= trade_cutoff
+        )
+        kept_risk_signals = select(RiskEvent.signal_id).where(
+            RiskEvent.signal_id.is_not(None), RiskEvent.created_at >= risk_cutoff
+        )
 
         unlinked_signals_query = (
             select(ModelSignal)
@@ -312,10 +368,31 @@ def cleanup_database(db_url: str, audit_db_url: str = None, dry_run: bool = Fals
         results["model_signals"] = len(unlinked_records)
 
         if unlinked_records:
-            logger.info(f"{'[DRY RUN] ' if dry_run else ''}Purging {len(unlinked_records)} unlinked signals older than {signal_cutoff.date()}")
+            logger.info(
+                f"{'[DRY RUN] ' if dry_run else ''}Purging {len(unlinked_records)} unlinked signals older than {signal_cutoff.date()}"
+            )
             if not dry_run:
                 # No archival for unlinked signals as per policy (ephemeral)
                 ids_to_delete = [s.id for s in unlinked_records]
+
+                # Cleanup BlockedSignalAnalysis for these signals
+                bsa_records = (
+                    session.execute(
+                        select(BlockedSignalAnalysis).where(
+                            BlockedSignalAnalysis.signal_id.in_(ids_to_delete)
+                        )
+                    )
+                    .scalars()
+                    .all()
+                )
+                if bsa_records:
+                    results["blocked_signal_analysis"] = len(bsa_records)
+                    session.execute(
+                        delete(BlockedSignalAnalysis).where(
+                            BlockedSignalAnalysis.signal_id.in_(ids_to_delete)
+                        )
+                    )
+
                 session.execute(delete(ModelSignal).where(ModelSignal.id.in_(ids_to_delete)))
 
         if not dry_run:
@@ -371,17 +448,16 @@ def main():
     cfg = get_config()
 
     # Determine DB URLs mirroring main.py logic
-    if args.db_url:
-        db_url = args.db_url
-    else:
-        db_val = cfg.database_url.get_secret_value()
-        db_url = db_val if "sqlite" in db_val else "sqlite:///trades.db"
+    db_url = args.db_url or cfg.database_url.get_secret_value()
+    audit_db_url = args.audit_db_url or cfg.database_url.get_secret_value()
 
-    if args.audit_db_url:
-        audit_db_url = args.audit_db_url
-    else:
-        db_val = cfg.database_url.get_secret_value()
-        audit_db_url = db_val if "sqlite" in db_val else "sqlite:///audit.db"
+    # Fallback for SQLite if not fully specified in environment
+    if not args.db_url and "://" not in db_url:
+        db_url = f"sqlite:///{db_url}" if db_url.endswith(".db") else "sqlite:///trades.db"
+    if not args.audit_db_url and "://" not in audit_db_url:
+        audit_db_url = (
+            f"sqlite:///{audit_db_url}" if audit_db_url.endswith(".db") else "sqlite:///audit.db"
+        )
 
     logs_dir = Path(args.logs_dir) if args.logs_dir else cfg.logs_dir
     backtest_dir = Path(args.backtest_dir) if args.backtest_dir else Path(__file__).resolve().parents[1] / "backtest_results"

--- a/tests/test_data_cleanup.py
+++ b/tests/test_data_cleanup.py
@@ -11,7 +11,15 @@ from sqlalchemy.pool import StaticPool
 
 from scripts.data_cleanup import cleanup_backtests, cleanup_database, cleanup_logs
 from src.core.audit_log import AuditEntry, Base as AuditBase
-from src.core.trade_logger import Base, ModelSignal, PerformanceMetric, RiskEvent, Trade
+from src.core.trade_logger import (
+    Base,
+    BlockedSignalAnalysis,
+    ExecutionQuality,
+    ModelSignal,
+    PerformanceMetric,
+    RiskEvent,
+    Trade,
+)
 
 
 class TestDataCleanup(unittest.TestCase):
@@ -126,11 +134,40 @@ class TestDataCleanup(unittest.TestCase):
 
             # 7. Old Trade (older than 7 years, should be purged)
             very_old_trade = Trade(
-                ticket=999, symbol="XAUUSD", direction=1, entry_price=1000.0,
-                lot_size=0.1, created_at=now - timedelta(days=3000)
+                ticket=999,
+                symbol="XAUUSD",
+                direction=1,
+                entry_price=1000.0,
+                lot_size=0.1,
+                created_at=now - timedelta(days=3000),
+            )
+            session.add(very_old_trade)
+            session.flush()
+
+            # 8. Execution Quality for very old trade (should be purged)
+            old_eq = ExecutionQuality(
+                trade_id=very_old_trade.id,
+                slippage_pips=0.5,
+                execution_latency_ms=25.0,
+                fill_quality_score=0.9,
+                edge_capture=0.1,
+                timing_efficiency=0.8,
+                alpha_decay_pips=0.0,
+                execution_cost_pips=0.2,
+                created_at=now - timedelta(days=3000),
             )
 
-            # 8. Audit Log entries
+            # 9. Blocked Signal Analysis for old unlinked signal (should be purged)
+            old_bsa = BlockedSignalAnalysis(
+                signal_id=old_unlinked.id,
+                opportunity_cost_pnl=50.0,
+                max_favorable_excursion=10.0,
+                max_adverse_excursion=2.0,
+                would_have_won=True,
+                created_at=now - timedelta(days=100),
+            )
+
+            # 10. Audit Log entries
             old_audit = AuditEntry(
                 actor="system", action="config_change", created_at=now - timedelta(days=3000)
             )
@@ -138,13 +175,15 @@ class TestDataCleanup(unittest.TestCase):
                 actor="system", action="startup", created_at=now - timedelta(days=10)
             )
 
-            session.add_all([trade, old_risk, new_risk, old_perf, very_old_trade, old_audit, new_audit])
+            session.add_all([trade, old_risk, new_risk, old_perf, old_eq, old_bsa, old_audit, new_audit])
             session.commit()
 
             # Capture IDs while session is still open
             new_unlinked_id = new_unlinked.id
             old_linked_id = old_linked.id
             old_unlinked_id = old_unlinked.id
+            old_eq_id = old_eq.id
+            old_bsa_id = old_bsa.id
 
         # Run cleanup on the in-memory DB
         # We need to monkeypatch create_engine or pass the engine
@@ -157,10 +196,12 @@ class TestDataCleanup(unittest.TestCase):
         finally:
             scripts.data_cleanup.create_engine = original_create_engine
 
-        self.assertEqual(results["model_signals"], 1) # only old_unlinked
-        self.assertEqual(results["risk_events"], 1)    # only old_risk
+        self.assertEqual(results["model_signals"], 1)  # only old_unlinked
+        self.assertEqual(results["risk_events"], 1)  # only old_risk
         self.assertEqual(results["performance_metrics"], 1)
-        self.assertEqual(results["trades"], 1) # very_old_trade
+        self.assertEqual(results["trades"], 1)  # very_old_trade
+        self.assertEqual(results["execution_qualities"], 1)
+        self.assertEqual(results["blocked_signal_analysis"], 1)
         self.assertEqual(results["audit_log"], 1)
 
         with self.Session() as session:
@@ -173,6 +214,12 @@ class TestDataCleanup(unittest.TestCase):
             trades = session.execute(select(Trade)).scalars().all()
             self.assertEqual(len(trades), 1)
             self.assertEqual(trades[0].ticket, 123)
+
+            eqs = session.execute(select(ExecutionQuality)).scalars().all()
+            self.assertEqual(len(eqs), 0)
+
+            bsas = session.execute(select(BlockedSignalAnalysis)).scalars().all()
+            self.assertEqual(len(bsas), 0)
 
             audit_entries = session.execute(select(AuditEntry)).scalars().all()
             self.assertEqual(len(audit_entries), 1)


### PR DESCRIPTION
This change establishes a formal enterprise-grade data retention policy and implementation for the MT5 AI Trading Bot.

Key updates include:
- Retention periods: Trades/Execution (7y), Risk/Metrics (2y), Logs/Unlinked Signals (90d).
- Automated cleanup script with dry-run mode and SHA256-verified archival.
- Safe deletion logic that preserves data linked to active audit-critical records.
- Comprehensive test coverage for new purging logic.

---
*PR created automatically by Jules for task [7629290016430726854](https://jules.google.com/task/7629290016430726854) started by @andonly1348*