### PR TITLE
Define Data Retention Policy and Implement Cleanup Automation

### DIFF
--- a/scripts/data_cleanup.py
+++ b/scripts/data_cleanup.py
@@ -256,7 +256,7 @@ def cleanup_database(
             if not dry_run:
                 # Archiving risk events (Audit 2-year category, archived before purge)
                 if archive_records(risk_records, "risk_events", archive_dir):
-                    # Also archive associated signals before deleting risk events
+                    # Also archive associated signals and analysis before deleting risk events
                     signal_ids = {r.signal_id for r in risk_records if r.signal_id}
                     if signal_ids:
                         signals_to_archive = (
@@ -267,6 +267,18 @@ def cleanup_database(
                             .all()
                         )
                         archive_records(signals_to_archive, "linked_risk_signals", archive_dir)
+
+                        bsa_to_archive = (
+                            session.execute(
+                                select(BlockedSignalAnalysis).where(
+                                    BlockedSignalAnalysis.signal_id.in_(signal_ids)
+                                )
+                            )
+                            .scalars()
+                            .all()
+                        )
+                        if bsa_to_archive:
+                            archive_records(bsa_to_archive, "linked_risk_bsa", archive_dir)
 
                     # Bulk delete
                     ids_to_delete = [r.id for r in risk_records]
@@ -328,7 +340,7 @@ def cleanup_database(
                             )
                         )
 
-                    # Also archive associated signals before deleting trades
+                    # Also archive associated signals and analysis before deleting trades
                     signal_ids = {t.signal_id for t in trade_records if t.signal_id}
                     if signal_ids:
                         signals_to_archive = (
@@ -339,6 +351,18 @@ def cleanup_database(
                             .all()
                         )
                         archive_records(signals_to_archive, "linked_signals", archive_dir)
+
+                        bsa_to_archive = (
+                            session.execute(
+                                select(BlockedSignalAnalysis).where(
+                                    BlockedSignalAnalysis.signal_id.in_(signal_ids)
+                                )
+                            )
+                            .scalars()
+                            .all()
+                        )
+                        if bsa_to_archive:
+                            archive_records(bsa_to_archive, "linked_bsa", archive_dir)
 
                     session.execute(delete(Trade).where(Trade.id.in_(ids_to_delete)))
                 else:


### PR DESCRIPTION
This submission establishes a formal data retention policy and provides an automated enforcement mechanism via `scripts/data_cleanup.py`. 

Key deliverables:
1. **Data Retention Policy (`docs/DATA_RETENTION_POLICY.md`)**: Defines clear retention windows aligned with financial compliance (7 years for trades/audit logs) and operational efficiency (90 days for logs/unlinked signals).
2. **Automated Cleanup Script (`scripts/data_cleanup.py`)**: A production-grade utility that:
   - Performs "Safe Deletion" by archiving critical data before purging.
   - Generates SHA256 checksums for all archives to ensure immutability.
   - Implements a proactive 500MB disk space gate.
   - Handles complex referential integrity (e.g., ensuring signals linked to active trades are not purged).
   - Supports `--dry-run` for safe operational verification.
3. **Automated Workflow**: Integrates with `.github/workflows/data-cleanup.yml` for weekly execution.

Verification:
- All 7 tests in `tests/test_data_cleanup.py` and `tests/test_data_cleanup_system.py` passed.
- Dry-run execution verified against a live (mocked) database.

---
*PR created automatically by Jules for task [3321016900700437446](https://jules.google.com/task/3321016900700437446) started by @andonly1348*