### PR TITLE
🗄️ Jules02: Database reliability improvement — Enable SQLite foreign keys and WAL mode

### DIFF
--- a/DATABASE_STANDARDS.md
+++ b/DATABASE_STANDARDS.md
@@ -382,3 +382,8 @@ The trade logging system has been implemented in `src/core/trade_logger.py` usin
 - Mandatory audit columns via `AuditMixin`.
 - SQLite compatibility using `render_as_batch=True`.
 - Automated performance reporting (Sharpe, Profit Factor, Max Drawdown).
+
+### Implementation Note (v1.2) - SQLite Hardening
+To ensure enterprise-grade reliability when using SQLite:
+- **Foreign Key Enforcement**: Enabled via SQLAlchemy event listeners (`PRAGMA foreign_keys=ON`). This ensures relational integrity that is disabled by default in SQLite.
+- **Write-Ahead Logging (WAL)**: Enabled via `PRAGMA journal_mode=WAL` to improve concurrency (allowing multiple readers and one writer) and provide better durability and performance.

--- a/src/core/database.py
+++ b/src/core/database.py
@@ -12,10 +12,24 @@ import logging
 from functools import lru_cache
 from typing import Any
 
-from sqlalchemy import Engine, create_engine, text
+from sqlalchemy import Engine, create_engine, event, text
 from sqlalchemy.orm import Session, sessionmaker
 
 logger = logging.getLogger(__name__)
+
+@event.listens_for(Engine, "connect")
+def set_sqlite_pragma(dbapi_connection, connection_record):
+    """
+    Harden SQLite connections by enabling foreign keys and WAL mode.
+    Only applied to SQLite connections.
+    """
+    import sqlite3
+    if isinstance(dbapi_connection, sqlite3.Connection):
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.execute("PRAGMA journal_mode=WAL")
+        cursor.close()
+        logger.debug("SQLite pragmas (foreign_keys, WAL) enabled.")
 
 @lru_cache(maxsize=16)
 def get_engine(db_url: str) -> Engine:

--- a/tests/test_execution_quality.py
+++ b/tests/test_execution_quality.py
@@ -223,8 +223,22 @@ def test_market_session_detection(analyzer):
 
 def test_execution_quality_persistence(analyzer):
     """Test that execution quality metrics can be persisted to DB."""
+    # Since foreign keys are now enforced, we must create a trade first
+    with analyzer.Session() as session:
+        trade = Trade(
+            ticket=1001,
+            symbol="XAUUSD",
+            direction=1,
+            entry_price=2000.0,
+            lot_size=0.1,
+            status="CLOSED"
+        )
+        session.add(trade)
+        session.commit()
+        trade_id = trade.id
+
     quality_data = TradeExecutionQuality(
-        trade_id=1, ticket=1001, symbol="XAUUSD", slippage_pips=1.2,
+        trade_id=trade_id, ticket=1001, symbol="XAUUSD", slippage_pips=1.2,
         execution_latency_ms=250.0, fill_quality_score=0.85,
         edge_capture=0.6, session="London", post_entry_drift_5m=0.5,
         post_entry_drift_15m=1.2, timing_efficiency=0.75,
@@ -237,7 +251,7 @@ def test_execution_quality_persistence(analyzer):
     analyzer.save_execution_quality(quality_data)
 
     with analyzer.Session() as session:
-        saved = session.query(ExecutionQuality).filter_by(trade_id=1).first()
+        saved = session.query(ExecutionQuality).filter_by(trade_id=trade_id).first()
         assert saved is not None
         assert saved.broker_slippage_pips == 0.9
         assert saved.effective_spread_pips == 2.0

--- a/tests/test_sqlite_hardening.py
+++ b/tests/test_sqlite_hardening.py
@@ -1,0 +1,59 @@
+
+import os
+import sqlite3
+import pytest
+from sqlalchemy import Column, Integer, ForeignKey, select
+from sqlalchemy.orm import declarative_base
+from src.core.database import get_engine, get_session_factory
+
+Base = declarative_base()
+
+class Parent(Base):
+    __tablename__ = 'test_parents'
+    id = Column(Integer, primary_key=True)
+
+class Child(Base):
+    __tablename__ = 'test_children'
+    id = Column(Integer, primary_key=True)
+    parent_id = Column(Integer, ForeignKey('test_parents.id'))
+
+@pytest.fixture
+def sqlite_engine():
+    db_path = "test_hardening.db"
+    if os.path.exists(db_path):
+        os.remove(db_path)
+
+    db_url = f"sqlite:///{db_path}"
+    engine = get_engine(db_url)
+    yield engine
+
+    # Cleanup
+    if os.path.exists(db_path):
+        os.remove(db_path)
+    for suffix in ["-wal", "-shm"]:
+        if os.path.exists(db_path + suffix):
+            os.remove(db_path + suffix)
+
+def test_sqlite_pragmas(sqlite_engine):
+    """Verify that WAL mode and Foreign Keys are enabled."""
+    with sqlite_engine.connect() as conn:
+        journal_mode = conn.exec_driver_sql("PRAGMA journal_mode").scalar()
+        assert journal_mode.lower() == "wal"
+
+        foreign_keys = conn.exec_driver_sql("PRAGMA foreign_keys").scalar()
+        assert foreign_keys == 1
+
+def test_foreign_key_enforcement(sqlite_engine):
+    """Verify that Foreign Key constraints are actually enforced by SQLite."""
+    Base.metadata.create_all(sqlite_engine)
+    Session = get_session_factory(sqlite_engine)
+
+    from sqlalchemy.exc import IntegrityError
+    with Session() as session:
+        # Attempt to insert a child with a non-existent parent
+        child = Child(id=1, parent_id=999)
+        session.add(child)
+        with pytest.raises(IntegrityError) as excinfo:
+            session.commit()
+        assert "FOREIGN KEY constraint failed" in str(excinfo.value)
+        session.rollback()


### PR DESCRIPTION
Harden SQLite configuration by enabling Foreign Key enforcement and WAL mode via SQLAlchemy event listeners. Includes a new test suite to verify the improvement.

---
*PR created automatically by Jules for task [12071119119403866304](https://jules.google.com/task/12071119119403866304) started by @xnessom*