### PR TITLE
Define Data Retention Policy and Implement Automated Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ python main.py --mode live --algo ensemble --confirm-live
 | [**SLO & Reliability Targets**](./docs/SLO_TARGETS.md) | **Measurable reliability standards and error budget framework.** |
 | [**Contributing Guide**](./docs/CONTRIBUTING.md) | **How to contribute safely and effectively.** |
 | [**Contribution Map**](./docs/CONTRIBUTION_MAP.md) | **Safe vs. Sensitive zone navigation.** |
+| [**Data Retention Policy**](./docs/DATA_RETENTION_POLICY.md) | **Policies for operational data retention and automated purging.** |
 | [**Disaster Recovery Plan**](./docs/DISASTER_RECOVERY.md) | **Procedures for database, log, and operational data recovery.** |
 
 ---

--- a/docs/DATA_RETENTION_POLICY.md
+++ b/docs/DATA_RETENTION_POLICY.md
@@ -63,9 +63,9 @@ Archives themselves are subject to a retention policy to prevent indefinite stor
 - **Cleanup**: The `scripts/data_cleanup.py` script is responsible for purging expired archives.
 
 ### 4.3 Automated Purging Schedule
-The automated cleanup script (`scripts/data_cleanup.py`) should be executed on a regular schedule.
-- **Recommended Schedule**: Weekly (Sundays at 00:00).
-- **Automation**: Managed via cron or CI/CD scheduled workflows.
+The automated cleanup script (`scripts/data_cleanup.py`) is executed on a regular schedule to ensure continuous compliance and storage hygiene.
+- **Schedule**: Weekly (Sundays at 00:00 UTC).
+- **Automation**: Managed via the `.github/workflows/data-cleanup.yml` GitHub Action.
 
 ### 4.4 Safe Deletion Logic
 - **Foreign Key Integrity**: The cleanup script ensures that `model_signals` linked to `trades` or `risk_events` are NOT deleted if the parent record is still within its retention window.
@@ -76,6 +76,6 @@ The automated cleanup script (`scripts/data_cleanup.py`) should be executed on a
 The primary mechanism for enforcement is the `scripts/data_cleanup.py` tool. It uses the `database_url` and `logs_dir` from the system configuration to target the correct data stores.
 
 ---
-**Version**: 1.4.0
-**Effective Date**: 2024-05-22
+**Version**: 1.4.1
+**Effective Date**: 2024-06-10
 **Owner**: Release Reliability & Governance (Jules03)

--- a/scripts/data_cleanup.py
+++ b/scripts/data_cleanup.py
@@ -19,6 +19,8 @@ from typing import Any, List, Optional
 from sqlalchemy import create_engine, delete, select
 from sqlalchemy.orm import sessionmaker
 
+__version__ = "1.1.0"
+
 # Add src to path to import models
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 


### PR DESCRIPTION
This PR establishes the enterprise data retention policy and provides the automated cleanup utility to enforce it. It includes retention windows for logs (90 days), trades (7 years), performance metrics (2 years), and backtests (1 year), along with safe deletion logic to protect linked audit-critical data. The process is automated via a weekly GitHub Action.

---
*PR created automatically by Jules for task [14422739388841355858](https://jules.google.com/task/14422739388841355858) started by @andonly1348*