### PR TITLE
Refine Signal Explainability with Institutional Metrics

### DIFF
--- a/docs/features/EXPLAINABILITY.md
+++ b/docs/features/EXPLAINABILITY.md
@@ -18,22 +18,24 @@ Provides a weighted breakdown of contributions from the ensemble's constituent m
 - **Confidence**: Model-specific certainty scores.
 - **Weight**: Current importance of the model in the ensemble.
 - **Dominance**: Identifies the primary driver of the final decision.
+- **Dominance Ratio**: Quantifies the relative influence of each model within the ensemble decision (e.g., "PPO provided 75% of the total weighted conviction").
 
 ### 3. Feature Contributions
-Attributes decisions to specific feature clusters and identifies confluence between supporting and opposing factors.
+Attributes decisions to specific feature clusters and identifies strategic confluence between technical setups and market regimes.
 - **Trend Cluster**: Contribution from moving averages (EMA), ADX, and Hilbert Transform (`ht_`) trendlines.
 - **Momentum Cluster**: Impact of RSI, MFI, MACD, Stochastic, and price velocity indicators (returns, log returns, and distance from moving averages).
 - **Volatility Cluster**: Impact of ATR, Bollinger Band width, Keltner Channels, and price action range features (`body_size`, `day_range`).
 - **Volume Cluster**: Influence of relative volume (`rvol`), OBV, VWAP distance, and volume profile proxies.
 - **Pattern Cluster**: Contribution from candle pattern recognition (e.g., Hammer, Engulfing).
 
-**Confluence Logic**: The system automatically categorizes feature impacts as either "Supported by" (aligning with the signal direction) or "Opposed by" (conflicting with the signal direction) in the natural language summary. This provides immediate clarity on decision tension.
+**Strategic Confluence**: The system automatically maps technical driver clusters against regime-specific strategic reasoning (e.g., momentum velocity in trending regimes). It categorizes feature impacts as "Strategic Confluence: High alignment from" or "Opposed by", providing immediate clarity on decision tension and strategic rationale.
 
 ### 4. Market Regime Context
 Provides the environmental background for the signal.
 - **Detected Regime**: (e.g., Trending, Ranging, News Shock).
 - **Regime Confidence**: Reliability of the regime classification.
 - **Favorable Check**: Explicitly flags whether the strategy is optimized for the current state (e.g., "Market state is considered favorable" vs "Market state is UNFAVORABLE/CAUTIONARY").
+- **Regime Alignment Score**: A quantitative measure (0.0 to 1.0) of strategy suitability for the detected market state.
 
 ### 5. Risk Assessment
 The final gate where signals are validated against institutional risk constraints.
@@ -100,6 +102,8 @@ The `machine_attribution` field provides high-fidelity metrics for post-trade an
 - **`risk_reward_ratio`**: The realized R:R for the trade.
 - **`risk_rejection_reasons`**: Structured list of reasons if a signal was blocked by the risk engine.
 - **`failed_execution_filters`**: Identification of specific execution gates (e.g., Spread, Timing) that prevented a trade.
+- **`regime_alignment_score`**: Quantified suitability of the market environment.
+- **`model_dominance_ratios`**: Per-model influence metrics for ensemble attribution.
 - **`feature_impacts`**: Aggregated cluster-level scores for automated alpha decay analysis.
 
 ## Institutional Analysis

--- a/src/core/explainability.py
+++ b/src/core/explainability.py
@@ -377,7 +377,6 @@ class SignalExplainer:
             )
 
         # 2. Model Attribution
-        attributions = []
         dominant_models = []
         max_weighted_conf = -1.0
         model_confidences = model_confidences or {}
@@ -458,7 +457,6 @@ class SignalExplainer:
                 summary="No market regime context available.",
             )
         elif hasattr(regime_info, "label"):  # RegimeInfo pydantic model
-            label_val = str(regime_info.label.value).lower()
             alignment = regime_info.confidence if regime_info.confidence > 0.6 else 0.4
             regime_context = RegimeContext(
                 regime_name=str(regime_info.label.value).title(),

--- a/src/core/explainability.py
+++ b/src/core/explainability.py
@@ -84,6 +84,9 @@ class ModelAttribution(BaseModel):
         ..., ge=0.0, le=1.0, description="Weight of this model in the ensemble (0.0 to 1.0)."
     )
     is_dominant: bool = Field(False, description="Whether this model drove the final decision")
+    dominance_ratio: float = Field(
+        0.0, ge=0.0, le=1.0, description="Relative influence of this model in the decision."
+    )
 
 
 class RiskAssessment(BaseModel):
@@ -130,6 +133,9 @@ class RegimeContext(BaseModel):
         "Normal", description="Current volatility level (Low, Normal, High, Extreme)"
     )
     is_favorable: bool = Field(True, description="Whether the regime is favorable for the strategy")
+    regime_alignment_score: float = Field(
+        0.0, ge=0.0, le=1.0, description="Quantitative strategy suitability for this regime."
+    )
     summary: str = Field(
         "Market state stable", description="Contextual summary of the market state"
     )
@@ -376,6 +382,10 @@ class SignalExplainer:
         max_weighted_conf = -1.0
         model_confidences = model_confidences or {}
 
+        # First pass: Calculate weighted confidences and identify dominance
+        total_weighted_conf = 0.0
+        temp_attributions = []
+
         for name, vote_idx in model_votes.items():
             try:
                 vote_dir = ModelAction(int(vote_idx)).to_direction()
@@ -386,15 +396,12 @@ class SignalExplainer:
                 vote_dir = SignalDirection.HOLD
 
             weight = model_weights.get(name, 0.0)
-
-            # Individual model confidence: use provided value, or fallback to ensemble
-            # confidence (if aligned) or neutral 0.5 (if not aligned).
             model_conf = model_confidences.get(name)
             if model_conf is None:
                 model_conf = confidence if vote_dir.value == direction else 0.5
 
-            # Only models aligned with the final direction can be dominant
             weighted_conf = weight * model_conf if vote_dir.value == direction else 0.0
+            total_weighted_conf += weighted_conf
 
             if weighted_conf > max_weighted_conf:
                 max_weighted_conf = weighted_conf
@@ -402,22 +409,32 @@ class SignalExplainer:
             elif abs(weighted_conf - max_weighted_conf) < 1e-6 and max_weighted_conf > 0:
                 dominant_models.append(name)
 
-            attributions.append(
-                {
-                    "model_name": name,
-                    "vote": vote_dir,
-                    "confidence": model_conf,
-                    "weight": weight,
-                    "is_dominant": False,  # Set in second pass
-                }
-            )
+            temp_attributions.append({
+                "model_name": name,
+                "vote": vote_dir,
+                "confidence": model_conf,
+                "weight": weight,
+                "weighted_conf": weighted_conf,
+            })
 
-        # Finalize dominant models and convert to objects
+        # Second pass: Calculate dominance ratio and finalize attribution objects
         final_attributions = []
-        for attr_dict in attributions:
-            if attr_dict["model_name"] in dominant_models:
-                attr_dict["is_dominant"] = True
-            final_attributions.append(ModelAttribution(**attr_dict))
+        for attr_dict in temp_attributions:
+            dom_ratio = (
+                attr_dict["weighted_conf"] / total_weighted_conf
+                if total_weighted_conf > 0
+                else 0.0
+            )
+            final_attributions.append(
+                ModelAttribution(
+                    model_name=attr_dict["model_name"],
+                    vote=attr_dict["vote"],
+                    confidence=attr_dict["confidence"],
+                    weight=attr_dict["weight"],
+                    is_dominant=attr_dict["model_name"] in dominant_models,
+                    dominance_ratio=dom_ratio,
+                )
+            )
 
         # 3. Risk Assessment
         risk_assessment = RiskAssessment(
@@ -437,14 +454,18 @@ class SignalExplainer:
                 confidence=0.0,
                 volatility_state="Normal",
                 is_favorable=True,
+                regime_alignment_score=0.5,
                 summary="No market regime context available.",
             )
         elif hasattr(regime_info, "label"):  # RegimeInfo pydantic model
+            label_val = str(regime_info.label.value).lower()
+            alignment = regime_info.confidence if regime_info.confidence > 0.6 else 0.4
             regime_context = RegimeContext(
                 regime_name=str(regime_info.label.value).title(),
                 confidence=regime_info.confidence,
                 volatility_state="High" if regime_info.volatility_index > 1.5 else "Normal",
                 is_favorable=regime_info.confidence > 0.6,
+                regime_alignment_score=alignment,
                 summary=f"Market in {regime_info.label.value} state with {regime_info.confidence:.1%} confidence.",
             )
         elif isinstance(regime_info, dict):
@@ -453,6 +474,7 @@ class SignalExplainer:
                 confidence=regime_info.get("confidence", 0.0),
                 volatility_state=regime_info.get("volatility", "Normal"),
                 is_favorable=regime_info.get("is_favorable", True),
+                regime_alignment_score=regime_info.get("alignment_score", 0.5),
                 summary=regime_info.get("summary", "Market state stable"),
             )
         else:
@@ -511,15 +533,27 @@ class SignalExplainer:
                     )
                 )
 
-        # 6. Generate Human Readable Summary with Confluence Logic
+        # 6. Generate Human Readable Summary with Strategic Reasoning
         dir_str = SignalDirection(direction).name
         reasoning = f"Ensemble generated a {dir_str} signal with {confidence:.1%} confidence. "
         if dominant_models:
             reasoning += f"Primary driver(s): {', '.join(dominant_models)}. "
 
-        reasoning += f"Market is currently in a {regime_context.regime_name} regime. "
+        # Strategic Context Mapping
+        regime_lower = regime_context.regime_name.lower()
+        strategic_edge = ""
+        if "trending" in regime_lower:
+            strategic_edge = "Trending regimes provide high-velocity environments for our momentum models."
+        elif "ranging" in regime_lower:
+            strategic_edge = "Mean-reversion setups are prioritized in ranging regimes to capture cyclical price action."
+        elif "volatile" in regime_lower:
+            strategic_edge = "Elevated volatility requires tighter execution gates and confluence between technical clusters."
+        else:
+            strategic_edge = "Market state stable, following base ensemble consensus."
+
+        reasoning += f"Market is currently in a {regime_context.regime_name} regime. {strategic_edge} "
         if regime_context.is_favorable:
-            reasoning += "Market state is considered favorable for this strategy. "
+            reasoning += "Market state is considered favorable for this strategy setup. "
         else:
             reasoning += "Market state is UNFAVORABLE/CAUTIONARY for this strategy. "
 
@@ -527,9 +561,6 @@ class SignalExplainer:
         supporting = []
         opposing = []
         for c in contributions:
-            # BUY (1) and score > 0 -> Supporting
-            # SELL (-1) and score < 0 -> Supporting
-            # Score 0 -> Neutral (Ignore)
             if c.contribution_score == 0:
                 continue
 
@@ -544,7 +575,7 @@ class SignalExplainer:
                 opposing.append(entry)
 
         if supporting:
-            reasoning += f"Supported by: {', '.join(supporting)}. "
+            reasoning += f"Strategic Confluence: High alignment from {', '.join(supporting)}. "
         if opposing:
             reasoning += f"Opposed by: {', '.join(opposing)}. "
 
@@ -567,7 +598,11 @@ class SignalExplainer:
                 f.filter_name for f in execution_summary.filters if not f.passed
             ],
             "regime_confluence": regime_context.confidence,
+            "regime_alignment_score": regime_context.regime_alignment_score,
             "dominant_models": dominant_models,
+            "model_dominance_ratios": {
+                attr.model_name: attr.dominance_ratio for attr in final_attributions
+            },
             "feature_impacts": {c.cluster_name: c.contribution_score for c in contributions},
         }
 

--- a/tests/test_explainability.py
+++ b/tests/test_explainability.py
@@ -258,8 +258,8 @@ def test_signal_explainer_feature_contributions():
     assert trend.contribution_score == 0.8
     assert trend.impact_level == "High"
 
-    # Check that high impact feature is in summary (now via Confluence Logic)
-    assert "Supported by: Trend (+0.80)" in explanation.human_readable_summary
+    # Check that high impact feature is in summary (now via Strategic Confluence)
+    assert "Strategic Confluence: High alignment from Trend (+0.80)" in explanation.human_readable_summary
 
     # Check machine attribution for features
     assert "feature_impacts" in explanation.machine_attribution
@@ -578,7 +578,7 @@ def test_human_readable_summary_confluence():
     )
 
     summary = explanation.human_readable_summary
-    assert "Supported by:" in summary
+    assert "Strategic Confluence: High alignment from" in summary
     assert "Momentum (+0.80)" in summary
     assert "Volume (+0.50)" in summary
     assert "Opposed by:" in summary
@@ -662,3 +662,77 @@ def test_terminal_formatting_icons_and_markers():
     assert "●●○" in formatted
     assert "High" in formatted
     assert "Medium" in formatted
+
+
+def test_strategic_confluence_summary():
+    """Verify the accuracy and depth of the generated natural language summaries."""
+    explainer = SignalExplainer()
+
+    # Case 1: Trending Regime
+    exp_trending = explainer.explain(
+        symbol="XAUUSD",
+        direction=1,
+        confidence=0.85,
+        model_votes={"ppo": 1},
+        model_weights={"ppo": 1.0},
+        risk_data={"passed": True},
+        regime_info={"name": "Trending", "is_favorable": True},
+        feature_impacts={"rsi": 0.8},
+    )
+    summary = exp_trending.human_readable_summary
+    assert "Trending regimes provide high-velocity environments" in summary
+    assert "Strategic Confluence: High alignment from Momentum (+0.80)" in summary
+
+    # Case 2: Ranging Regime
+    exp_ranging = explainer.explain(
+        symbol="XAUUSD",
+        direction=-1,
+        confidence=0.75,
+        model_votes={"ppo": 2},
+        model_weights={"ppo": 1.0},
+        risk_data={"passed": True},
+        regime_info={"name": "Ranging", "is_favorable": True},
+        feature_impacts={"slope": -0.6},
+    )
+    assert "Mean-reversion setups are prioritized in ranging regimes" in exp_ranging.human_readable_summary
+    assert "Strategic Confluence: High alignment from Trend (-0.60)" in exp_ranging.human_readable_summary
+
+
+def test_advanced_metrics_calculation():
+    """Ensure dominance_ratio and regime_alignment_score are correctly derived."""
+    explainer = SignalExplainer()
+
+    # Setup ensemble with different confidences
+    model_votes = {"ppo": 1, "lstm": 1}
+    model_weights = {"ppo": 0.7, "lstm": 0.3}
+    model_confidences = {"ppo": 0.9, "lstm": 0.7}
+
+    explanation = explainer.explain(
+        symbol="XAUUSD",
+        direction=1,
+        confidence=0.8,
+        model_votes=model_votes,
+        model_weights=model_weights,
+        risk_data={"passed": True},
+        regime_info={"name": "Trending", "confidence": 0.95, "alignment_score": 0.9},
+        model_confidences=model_confidences,
+    )
+
+    ppo_attr = next(a for a in explanation.model_attributions if a.model_name == "ppo")
+    lstm_attr = next(a for a in explanation.model_attributions if a.model_name == "lstm")
+
+    # Weighted confidences:
+    # ppo: 0.7 * 0.9 = 0.63
+    # lstm: 0.3 * 0.7 = 0.21
+    # total: 0.84
+    # ppo ratio: 0.63 / 0.84 = 0.75
+    # lstm ratio: 0.21 / 0.84 = 0.25
+
+    assert abs(ppo_attr.dominance_ratio - 0.75) < 1e-6
+    assert abs(lstm_attr.dominance_ratio - 0.25) < 1e-6
+    assert explanation.regime_context.regime_alignment_score == 0.9
+
+    # Check machine attribution
+    attr = explanation.machine_attribution
+    assert attr["model_dominance_ratios"]["ppo"] == ppo_attr.dominance_ratio
+    assert attr["regime_alignment_score"] == 0.9


### PR DESCRIPTION
This PR enhances the signal explainability module by adding granular institutional metrics and strategic reasoning. Key improvements include:
- Addition of 'dominance_ratio' to ModelAttribution to quantify individual model influence in ensemble decisions.
- Addition of 'regime_alignment_score' to RegimeContext to measure strategy suitability for the detected market state.
- Refined natural language summary generation with 'Strategic Confluence' logic, mapping technical drivers against regime-specific strategic reasoning.
- Expanded machine-readable attribution dictionary for automated post-trade analytics.
- Updated documentation and comprehensive unit tests (23 passing) to verify the new metrics and summaries.

---
*PR created automatically by Jules for task [4283173736393560842](https://jules.google.com/task/4283173736393560842) started by @saysgrok*