### PR TITLE
feat: 🧬 Jules02: Synthetic test scenarios — Adversarial and transition builders

### DIFF
--- a/docs/testing/SYNTHETIC_DATA.md
+++ b/docs/testing/SYNTHETIC_DATA.md
@@ -4,7 +4,7 @@ This document outlines the synthetic data generation and risk scenario building 
 
 ## ScenarioGenerator
 
-Located in `src/utils/synthetic_data.py`, the `ScenarioGenerator` provides deterministic OHLCV data for various market regimes.
+Located in , the  provides deterministic OHLCV data for various market regimes.
 
 ### Supported Regimes
 
@@ -31,21 +31,21 @@ Located in `src/utils/synthetic_data.py`, the `ScenarioGenerator` provides deter
     - **outliers**: Ghost ticks or extreme price spikes (e.g., bad feed).
     - **zero_volume**: Price moves but volume is reported as zero.
     - **gaps**: Price jumps without continuity (slippage or weekend gaps).
-- **Price Continuity**: The generator ensures `Open[i] == Close[i-1]` for standard regimes, providing realistic price action for backtesting.
+- **Price Continuity**: The generator ensures  for standard regimes, providing realistic price action for backtesting.
 
 ## BacktestScenarioBuilder
 
-Located in `src/utils/synthetic_data.py`, the `BacktestScenarioBuilder` provides deterministic price sequences designed to verify the mathematical correctness of the `BacktestEngine`.
+Located in , the  provides deterministic price sequences designed to verify the mathematical correctness of the .
 
 ### Key Methods
 
-- **drawdown_recovery(n_steps, start_price)**: Creates a 10% drawdown followed by a 20% gain. Used to verify `max_drawdown` and `recovery_factor` calculations.
+- **drawdown_recovery(n_steps, start_price)**: Creates a 10% drawdown followed by a 20% gain. Used to verify  and  calculations.
 - **wick_traps(n_steps, start_price)**: Creates bars where both SL and TP levels are touched. Verifies the conservative "SL-first" exit policy.
 - **steady_sharpe(n_steps, start_price)**: Near-perfect linear trend with minimal noise to produce high Sharpe and Profit Factor for baseline testing.
 
 ## ExecutionScenarioBuilder
 
-Located in `src/utils/synthetic_data.py`, the `ExecutionScenarioBuilder` generates paired `TradeSignal` and `pd.DataFrame` (market data) designed to test specific layers of the `ExecutionFilter`.
+Located in , the  generates paired  and  (market data) designed to test specific layers of the .
 
 ### Key Scenarios
 
@@ -62,20 +62,20 @@ Located in `src/utils/synthetic_data.py`, the `ExecutionScenarioBuilder` generat
 
 ## RegimeScenarioBuilder
 
-Located in `src/utils/synthetic_data.py`, the `RegimeScenarioBuilder` generates deterministic datasets specifically designed to trigger each `MarketRegime` label in the `RegimeDetector`.
+Located in , the  generates deterministic datasets specifically designed to trigger each  label in the .
 
 ### Key Methods
 
-- **trending()**: Triggers `MarketRegime.TRENDING`.
-- **ranging()**: Triggers `MarketRegime.RANGING`.
-- **mean_reversion()**: Triggers `MarketRegime.MEAN_REVERSION`.
-- **volatile_breakout()**: Triggers `MarketRegime.VOLATILE_BREAKOUT`.
-- **low_volatility_drift()**: Triggers `MarketRegime.LOW_VOLATILITY_DRIFT`.
-- **news_shock()**: Triggers `MarketRegime.NEWS_SHOCK`.
+- **trending()**: Triggers .
+- **ranging()**: Triggers .
+- **mean_reversion()**: Triggers .
+- **volatile_breakout()**: Triggers .
+- **low_volatility_drift()**: Triggers .
+- **news_shock()**: Triggers .
 
 ## ModelHealthGenerator
 
-Located in `src/utils/synthetic_data.py`, the `ModelHealthGenerator` provides deterministic model health metrics for testing stability guards.
+Located in , the  provides deterministic model health metrics for testing stability guards.
 
 ### Supported States
 
@@ -86,12 +86,12 @@ Located in `src/utils/synthetic_data.py`, the `ModelHealthGenerator` provides de
 
 ## RiskScenarioBuilder
 
-Located in `src/utils/synthetic_data.py`, the `RiskScenarioBuilder` generates deterministic sequences of `TradeSignal` objects.
+Located in , the  generates deterministic sequences of  objects.
 
 ### Key Methods
 
 - **consecutive_losses(n_signals, symbol, start_price)**:
-  Generates `n_signals` that are likely to result in losses. This is critical for testing:
+  Generates  that are likely to result in losses. This is critical for testing:
   - Daily loss limits
   - Circuit breakers (drawdown halts)
   - Consecutive loss counters
@@ -102,14 +102,14 @@ Located in `src/utils/synthetic_data.py`, the `RiskScenarioBuilder` generates de
   - Signal validation gate behavior under high uncertainty
 
 - **daily_loss_breach(symbol, price, n_losses)** (New):
-  Generates a sequence of high-impact losing signals. Used to verify that the `RiskManager` correctly halts trading after the daily loss percentage floor is hit.
+  Generates a sequence of high-impact losing signals. Used to verify that the  correctly halts trading after the daily loss percentage floor is hit.
 
 - **drawdown_circuit_breaker(symbol, price)** (New):
   Generates an extreme losing scenario designed to trigger the system-wide 15% drawdown circuit breaker, ensuring all execution is blocked until manual intervention.
 
 ## MacroScenarioBuilder
 
-Located in `src/utils/synthetic_data.py`, the `MacroScenarioBuilder` generates deterministic `MacroEvent` objects for risk testing.
+Located in , the  generates deterministic  objects for risk testing.
 
 ### Key Scenarios
 
@@ -119,14 +119,34 @@ Located in `src/utils/synthetic_data.py`, the `MacroScenarioBuilder` generates d
 
 ## SystemContextBuilder
 
-Located in `src/utils/synthetic_data.py`, the `SystemContextBuilder` generates integrated test contexts combining price action, macro events, and risk status.
+Located in , the  generates integrated test contexts combining price action, macro events, and risk status.
 
 ### Key Contexts
 
 - **normal_trading**: Context for standard, low-risk trading.
-- **high_impact_macro_event**: Context during a High-Impact news release (NFP), including a defensive `RiskStatus`.
-- **extreme_volatility_with_risk_block**: Context with extreme price action (Flash Crash) and a defensive `RiskStatus` (FOMC news block).
+- **high_impact_macro_event**: Context during a High-Impact news release (NFP), including a defensive .
+- **extreme_volatility_with_risk_block**: Context with extreme price action (Flash Crash) and a defensive  (FOMC news block).
+
+## RegimeTransitionScenarioBuilder
+
+Located in , this builder generates sequences that transition between market states to test transition-score sensitivity.
+
+### Key Methods
+
+- **ranging_to_news_shock()**: Stable ranging followed by a sudden extreme news spike.
+- **trending_to_reversal()**: Strong bullish trend followed by exhaustion and sharp reversal.
+- **volatile_to_ranging()**: Extreme volatility phase that cools down into stable ranging.
+
+## AdversarialScenarioBuilder
+
+Located in , this builder creates "trap" scenarios to test technical robustness and noise rejection.
+
+### Key Scenarios
+
+- **wick_trap_cascade()**: Sequence of bars with small bodies but massive alternating wicks to test stop-loss sensitivity.
+- **liquidity_void()**: Price jumps between bars without continuity (gaps) to test gap-detection logic.
+- **vov_explosion()**: Ranging data where the volatility itself is extremely unstable to test VoV filters.
 
 ## Usage in Tests
 
-These tools are designed to make tests deterministic and broad. See `tests/test_risk_scenarios.py` and `tests/test_synthetic_data.py` for implementation examples.
+These tools are designed to make tests deterministic and broad. See  and  for implementation examples.

--- a/src/utils/synthetic_data.py
+++ b/src/utils/synthetic_data.py
@@ -798,6 +798,15 @@ class RegimeScenarioBuilder:
         """Triggers MarketRegime.NEWS_SHOCK."""
         return self.gen.generate(n_steps=150, regime="news_shock")
 
+    def volatile_breakout_sustained(self, n_steps: int = 150) -> pd.DataFrame:
+        """Triggers MarketRegime.VOLATILE_BREAKOUT with a sustained expansion."""
+        mid = n_steps * 2 // 3
+        returns_low = self.gen.rng.normal(0, 0.0001, mid)
+        # Sustained 1% moves for expansion phase
+        returns_high = self.gen.rng.normal(0.01, 0.001, n_steps - mid)
+        returns = np.concatenate([returns_low, returns_high])
+        return self.gen._generate_base(n_steps, 2300.0, returns)
+
 
 class PortfolioScenarioBuilder:
     """
@@ -991,3 +1000,98 @@ class SystemContextBuilder:
             reason="Critical FOMC meeting in progress.",
         )
         return df, [event], risk
+
+
+class RegimeTransitionScenarioBuilder:
+    """
+    Generates deterministic price sequences that transition between market regimes.
+    Useful for testing transition_score and adaptive risk logic.
+    """
+
+    def __init__(self, seed: int = 42):
+        self.gen = ScenarioGenerator(seed=seed)
+
+    def ranging_to_news_shock(self, n_steps: int = 200, start_price: float = 2300.0) -> pd.DataFrame:
+        """Stable ranging followed by a sudden extreme news spike."""
+        mid = n_steps // 2
+        # Ranging phase: very low vol
+        returns_ranging = self.gen.rng.normal(0, 0.00001, mid)
+        # News shock phase: massive spike (sustained for a few bars to affect rolling windows)
+        returns_news = self.gen.rng.normal(0, 0.0001, n_steps - mid)
+        returns_news[0:5] = 0.08  # 8% spike sustained for 5 bars to blow up ATR ratio
+
+        returns = np.concatenate([returns_ranging, returns_news])
+        return self.gen._generate_base(n_steps, start_price, returns)
+
+    def trending_to_reversal(self, n_steps: int = 200, start_price: float = 2300.0) -> pd.DataFrame:
+        """Strong bullish trend followed by exhaustion and sharp reversal."""
+        mid = n_steps // 2
+        # Bullish trend: steady growth
+        returns_trend = self.gen.rng.normal(0.001, 0.0002, mid)
+        # Reversal: sharp drop
+        returns_reversal = self.gen.rng.normal(-0.0015, 0.0003, n_steps - mid)
+
+        returns = np.concatenate([returns_trend, returns_reversal])
+        return self.gen._generate_base(n_steps, start_price, returns)
+
+    def volatile_to_ranging(self, n_steps: int = 200, start_price: float = 2300.0) -> pd.DataFrame:
+        """Extreme volatility phase that cools down into stable ranging."""
+        mid = n_steps // 2
+        # Volatile phase: high variance
+        returns_volatile = self.gen.rng.normal(0, 0.01, mid)
+        # Cooling down to ranging: very low variance
+        returns_ranging = self.gen.rng.normal(0, 0.0001, n_steps - mid)
+
+        returns = np.concatenate([returns_volatile, returns_ranging])
+        return self.gen._generate_base(n_steps, start_price, returns)
+
+
+class AdversarialScenarioBuilder:
+    """
+    Generates deterministic price sequences designed to trick filters or trigger edge cases.
+    """
+
+    def __init__(self, seed: int = 42):
+        self.gen = ScenarioGenerator(seed=seed)
+
+    def wick_trap_cascade(self, n_steps: int = 50, start_price: float = 2300.0) -> pd.DataFrame:
+        """
+        Sequence of bars with small bodies but massive alternating wicks.
+        Tests stop-loss sensitivity and noise filtering.
+        """
+        df = self.gen.generate(n_steps, regime="ranging", start_price=start_price, volatility=0.0001)
+        for i in range(10, 20):
+            idx = df.index[i]
+            # Alternate upward and downward wicks
+            if i % 2 == 0:
+                df.at[idx, "high"] = df.at[idx, "close"] + 20.0
+            else:
+                df.at[idx, "low"] = df.at[idx, "close"] - 20.0
+        return df
+
+    def liquidity_void(self, n_steps: int = 50, start_price: float = 2300.0) -> pd.DataFrame:
+        """
+        Price jumps between bars without continuity (gaps).
+        Tests gap-detection and continuity-enforcement logic.
+        """
+        df = self.gen.generate(n_steps, regime="ranging", start_price=start_price, volatility=0.0005)
+        # Inject major gaps
+        gap_indices = [15, 30, 45]
+        for idx_pos in gap_indices:
+            if idx_pos < len(df):
+                idx = df.index[idx_pos]
+                gap = 50.0 if idx_pos % 2 == 0 else -50.0
+                df.loc[idx:, ["open", "high", "low", "close"]] += gap
+        return df
+
+    def vov_explosion(self, n_steps: int = 150, start_price: float = 2300.0) -> pd.DataFrame:
+        """
+        Ranging data where the volatility itself is extremely unstable.
+        Tests volatility-of-volatility (VoV) and stability metrics.
+        """
+        returns = np.zeros(n_steps)
+        for i in range(n_steps):
+            # Variance itself oscillates violently between extreme states
+            vol = 0.05 if (i // 10) % 2 == 0 else 0.00001
+            returns[i] = self.gen.rng.normal(0, vol)
+        return self.gen._generate_base(n_steps, start_price, returns)

--- a/src/utils/synthetic_data.py
+++ b/src/utils/synthetic_data.py
@@ -841,7 +841,9 @@ class PortfolioScenarioBuilder:
         requests = [
             AllocationRequest(strategy_id="gold_rl_1", risk_pct=0.15),
             AllocationRequest(strategy_id="gold_rl_2", risk_pct=0.15),
-            AllocationRequest(strategy_id="gold_rl_3", risk_pct=0.15),  # Should hit XAUUSD 0.4 limit
+            AllocationRequest(
+                strategy_id="gold_rl_3", risk_pct=0.15
+            ),  # Should hit XAUUSD 0.4 limit
             AllocationRequest(strategy_id="eur_rl_1", risk_pct=0.15),  # Should hit RL 0.4 limit
         ]
         return configs, requests
@@ -863,13 +865,15 @@ class PortfolioScenarioBuilder:
         Generates requests that push total portfolio heat toward and past 0.7 limit.
         """
         configs = [
-            StrategyConfig(strategy_id=f"strat_{i}", symbol=f"SYM_{i}", model_family=f"FAM_{i}", capital_cap=100000)
+            StrategyConfig(
+                strategy_id=f"strat_{i}",
+                symbol=f"SYM_{i}",
+                model_family=f"FAM_{i}",
+                capital_cap=100000,
+            )
             for i in range(5)
         ]
-        requests = [
-            AllocationRequest(strategy_id=f"strat_{i}", risk_pct=0.15)
-            for i in range(5)
-        ]
+        requests = [AllocationRequest(strategy_id=f"strat_{i}", risk_pct=0.15) for i in range(5)]
         # 5 * 0.15 = 0.75 (> 0.7)
         return configs, requests
 
@@ -985,7 +989,9 @@ class SystemContextBuilder:
         )
         return df, [event], risk
 
-    def extreme_volatility_with_risk_block(self) -> tuple[pd.DataFrame, list[MacroEvent], RiskStatus]:
+    def extreme_volatility_with_risk_block(
+        self,
+    ) -> tuple[pd.DataFrame, list[MacroEvent], RiskStatus]:
         """Context with extreme price action and defensive risk positioning."""
         start_date = datetime(2024, 5, 22, 16, 0, tzinfo=UTC)
         df = self.price_gen.generate(n_steps=200, regime="flash_crash", start_date=start_date)
@@ -1011,7 +1017,9 @@ class RegimeTransitionScenarioBuilder:
     def __init__(self, seed: int = 42):
         self.gen = ScenarioGenerator(seed=seed)
 
-    def ranging_to_news_shock(self, n_steps: int = 200, start_price: float = 2300.0) -> pd.DataFrame:
+    def ranging_to_news_shock(
+        self, n_steps: int = 200, start_price: float = 2300.0
+    ) -> pd.DataFrame:
         """Stable ranging followed by a sudden extreme news spike."""
         mid = n_steps // 2
         # Ranging phase: very low vol
@@ -1059,7 +1067,9 @@ class AdversarialScenarioBuilder:
         Sequence of bars with small bodies but massive alternating wicks.
         Tests stop-loss sensitivity and noise filtering.
         """
-        df = self.gen.generate(n_steps, regime="ranging", start_price=start_price, volatility=0.0001)
+        df = self.gen.generate(
+            n_steps, regime="ranging", start_price=start_price, volatility=0.0001
+        )
         for i in range(10, 20):
             idx = df.index[i]
             # Alternate upward and downward wicks
@@ -1074,7 +1084,9 @@ class AdversarialScenarioBuilder:
         Price jumps between bars without continuity (gaps).
         Tests gap-detection and continuity-enforcement logic.
         """
-        df = self.gen.generate(n_steps, regime="ranging", start_price=start_price, volatility=0.0005)
+        df = self.gen.generate(
+            n_steps, regime="ranging", start_price=start_price, volatility=0.0005
+        )
         # Inject major gaps
         gap_indices = [15, 30, 45]
         for idx_pos in gap_indices:

--- a/tests/test_adversarial_scenarios.py
+++ b/tests/test_adversarial_scenarios.py
@@ -1,0 +1,89 @@
+"""
+Tests for Adversarial and Transition Scenario Builders.
+"""
+import pytest
+import numpy as np
+import pandas as pd
+from src.utils.synthetic_data import RegimeTransitionScenarioBuilder, AdversarialScenarioBuilder
+from src.models.regime_detector import RegimeDetector, MarketRegime
+
+@pytest.fixture
+def transition_builder():
+    return RegimeTransitionScenarioBuilder(seed=42)
+
+@pytest.fixture
+def adversarial_builder():
+    return AdversarialScenarioBuilder(seed=42)
+
+@pytest.fixture
+def detector():
+    return RegimeDetector(window=20, long_window=100)
+
+def test_ranging_to_news_shock(transition_builder, detector):
+    df = transition_builder.ranging_to_news_shock(n_steps=200)
+
+    # Analyze the transition
+    # First half should be ranging
+    info_start = detector.detect(df.iloc[:100])
+    assert info_start.label == MarketRegime.RANGING
+
+    # At the peak of the shock
+    info_shock = detector.detect(df.iloc[:110])
+    # News shock detection is sensitive to the window.
+    # Let's verify it triggers a high volatility/transition state.
+    assert info_shock.label in [MarketRegime.NEWS_SHOCK, MarketRegime.VOLATILE_BREAKOUT]
+    assert info_shock.transition_score > 0.5
+
+def test_trending_to_reversal(transition_builder, detector):
+    df = transition_builder.trending_to_reversal(n_steps=200)
+
+    # First half: Trending
+    info_trend = detector.detect(df.iloc[:100])
+    assert info_trend.label == MarketRegime.TRENDING
+
+    # After reversal
+    info_reversal = detector.detect(df)
+    # Reversal might be classified as Volatile Breakout or Trending (bearish) or News Shock
+    # depending on sharpness.
+    assert info_reversal.label != MarketRegime.TRENDING or info_reversal.raw_features["slope"] < 0
+
+def test_volatile_to_ranging(transition_builder, detector):
+    df = transition_builder.volatile_to_ranging(n_steps=200)
+
+    # End state should be ranging
+    info_end = detector.detect(df)
+    assert info_end.label == MarketRegime.RANGING
+
+def test_wick_trap_cascade(adversarial_builder):
+    df = adversarial_builder.wick_trap_cascade(n_steps=50)
+
+    # Check for massive wicks in the target range
+    for i in range(10, 20):
+        if i % 2 == 0:
+            assert df.iloc[i]["high"] > df.iloc[i]["close"] + 15.0
+        else:
+            assert df.iloc[i]["low"] < df.iloc[i]["close"] - 15.0
+
+def test_liquidity_void(adversarial_builder):
+    df = adversarial_builder.liquidity_void(n_steps=50)
+
+    # Check for continuity breaks (Open[i] != Close[i-1])
+    opens = df["open"].values[1:]
+    closes = df["close"].values[:-1]
+
+    has_break = False
+    for o, c in zip(opens, closes):
+        if abs(o - c) > 10.0:
+            has_break = True
+            break
+    assert has_break
+
+def test_vov_explosion(adversarial_builder, detector):
+    df = adversarial_builder.vov_explosion(n_steps=150)
+
+    # Label history and check vol_of_vol feature
+    df_labeled = detector.label_history(df)
+    vov_values = df_labeled["regime_transition_score"].values # Transition score incorporates VOV
+
+    # In vov_explosion, we expect some very high transition scores due to unstable variance
+    assert vov_values.max() > 0.4

--- a/tests/test_adversarial_scenarios.py
+++ b/tests/test_adversarial_scenarios.py
@@ -1,23 +1,27 @@
 """
 Tests for Adversarial and Transition Scenario Builders.
 """
+
 import pytest
-import numpy as np
-import pandas as pd
-from src.utils.synthetic_data import RegimeTransitionScenarioBuilder, AdversarialScenarioBuilder
-from src.models.regime_detector import RegimeDetector, MarketRegime
+
+from src.models.regime_detector import MarketRegime, RegimeDetector
+from src.utils.synthetic_data import AdversarialScenarioBuilder, RegimeTransitionScenarioBuilder
+
 
 @pytest.fixture
 def transition_builder():
     return RegimeTransitionScenarioBuilder(seed=42)
 
+
 @pytest.fixture
 def adversarial_builder():
     return AdversarialScenarioBuilder(seed=42)
 
+
 @pytest.fixture
 def detector():
     return RegimeDetector(window=20, long_window=100)
+
 
 def test_ranging_to_news_shock(transition_builder, detector):
     df = transition_builder.ranging_to_news_shock(n_steps=200)
@@ -34,6 +38,7 @@ def test_ranging_to_news_shock(transition_builder, detector):
     assert info_shock.label in [MarketRegime.NEWS_SHOCK, MarketRegime.VOLATILE_BREAKOUT]
     assert info_shock.transition_score > 0.5
 
+
 def test_trending_to_reversal(transition_builder, detector):
     df = transition_builder.trending_to_reversal(n_steps=200)
 
@@ -47,12 +52,14 @@ def test_trending_to_reversal(transition_builder, detector):
     # depending on sharpness.
     assert info_reversal.label != MarketRegime.TRENDING or info_reversal.raw_features["slope"] < 0
 
+
 def test_volatile_to_ranging(transition_builder, detector):
     df = transition_builder.volatile_to_ranging(n_steps=200)
 
     # End state should be ranging
     info_end = detector.detect(df)
     assert info_end.label == MarketRegime.RANGING
+
 
 def test_wick_trap_cascade(adversarial_builder):
     df = adversarial_builder.wick_trap_cascade(n_steps=50)
@@ -64,6 +71,7 @@ def test_wick_trap_cascade(adversarial_builder):
         else:
             assert df.iloc[i]["low"] < df.iloc[i]["close"] - 15.0
 
+
 def test_liquidity_void(adversarial_builder):
     df = adversarial_builder.liquidity_void(n_steps=50)
 
@@ -72,18 +80,19 @@ def test_liquidity_void(adversarial_builder):
     closes = df["close"].values[:-1]
 
     has_break = False
-    for o, c in zip(opens, closes):
+    for o, c in zip(opens, closes, strict=False):
         if abs(o - c) > 10.0:
             has_break = True
             break
     assert has_break
+
 
 def test_vov_explosion(adversarial_builder, detector):
     df = adversarial_builder.vov_explosion(n_steps=150)
 
     # Label history and check vol_of_vol feature
     df_labeled = detector.label_history(df)
-    vov_values = df_labeled["regime_transition_score"].values # Transition score incorporates VOV
+    vov_values = df_labeled["regime_transition_score"].values  # Transition score incorporates VOV
 
     # In vov_explosion, we expect some very high transition scores due to unstable variance
     assert vov_values.max() > 0.4


### PR DESCRIPTION
This PR introduces two new specialized builder classes to `src/utils/synthetic_data.py`: `RegimeTransitionScenarioBuilder` and `AdversarialScenarioBuilder`. These builders provide deterministic price sequences for testing complex market state transitions and adversarial edge cases like wick traps and liquidity voids. A new test suite `tests/test_adversarial_scenarios.py` is included to verify these builders. Additionally, a new method `volatile_breakout_sustained` was added to `RegimeScenarioBuilder` to provide more robust testing for regime detection.

---
*PR created automatically by Jules for task [12600204452141990012](https://jules.google.com/task/12600204452141990012) started by @xnessom*