### PR TITLE
Fix Reporting Pydantic Models and Enhance Research Templates

### DIFF
--- a/docs/research/REPORTING_SYSTEM.md
+++ b/docs/research/REPORTING_SYSTEM.md
@@ -19,6 +19,14 @@ The research reporting system is a high-fidelity audit framework designed to pro
     - **Interactive UX:** Sticky navigation headers with scroll progress indicators, tooltips for institutional metrics, and interactive card hover effects.
     - **Accessibility:** ARIA-hardened accessibility and print-optimized CSS for PDF generation.
 - **Modular Architecture:** Pydantic-based data models for extensible research sections covering Regimes, Stress Tests, Hyperopt, Journal Mining (Trade Patterns), Model Drift (PSI), Capital Allocation, Benchmarking, RL Evaluation, Rare Event Simulations, Confidence Calibration, Execution Quality, Strategic Confluence, and Audit Methodology.
+- **Sectional Scannability:** HTML reports feature top-level 'Summary' status badges for each analytical section (e.g., RESILIENCE: PASS, DRIFT: STABLE), allowing stakeholders to quickly identify areas of concern.
+
+## Data Models and Constraints
+
+To ensure robust serialization and prevent runtime errors, the reporting system follows strict Pydantic best practices:
+
+- **Field Ordering:** In all research section models (e.g., `StressedMetric`, `SignalMotif`), fields with default values MUST follow all fields without default values. This prevents `PydanticUserError` during model instantiation.
+- **Type Safety:** All metrics are strictly typed to ensure consistency across the research pipeline.
 
 ## Components
 

--- a/src/research/reporting.py
+++ b/src/research/reporting.py
@@ -44,9 +44,9 @@ class StressedMetric(BaseModel):
     total_return: str
     max_drawdown: str
     sharpe: str
+    outcome: str
     recovery_factor: str = "0.00"
     profit_factor: str = "0.00"
-    outcome: str
 
 
 class StressTestSection(BaseModel):
@@ -101,9 +101,9 @@ class SignalMotif(BaseModel):
     direction: int
     volatility_bucket: str
     confidence_bucket: str
-    session: str = "Unknown"
     frequency: int
     win_rate: float
+    session: str = "Unknown"
     expectancy: float = 0.0
     efficiency_ratio: float = 0.0
     cluster_frequency: int = 0
@@ -142,8 +142,8 @@ class DriftMetric(BaseModel):
     baseline: str
     current: str
     drift_pct: float
-    psi_score: float = 0.0
     status: str
+    psi_score: float = 0.0
 
 
 class ModelDriftSection(BaseModel):
@@ -320,10 +320,11 @@ class ResearchReport(BaseModel):
     """Structured research report container."""
 
     title: str
+    executive_summary: str
+    conclusion: str
     timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
     author: str = "Jules Research"
     overall_status: str = "PROVISIONAL"
-    executive_summary: str
 
     regime_analysis: RegimeSection | None = None
     stress_tests: StressTestSection | None = None
@@ -339,7 +340,6 @@ class ResearchReport(BaseModel):
     strategic_confluence: StrategicConfluenceSection | None = None
     methodology: MethodologySection | None = None
 
-    conclusion: str
     recommendations: list[str] = Field(default_factory=list)
 
 

--- a/src/research/templates/research_report.html.j2
+++ b/src/research/templates/research_report.html.j2
@@ -217,6 +217,7 @@
     {% if regime_analysis %}
     {% set ns.count = ns.count + 1 %}
     <section id="regime-analysis">
+        <div style="float: right;"><span class="badge badge-stable">ANALYTICAL</span></div>
         <h2>{{ ns.count }}. Market Regime Analysis</h2>
         <p>{{ regime_analysis.summary }}</p>
         <table>
@@ -249,6 +250,13 @@
     {% if stress_tests %}
     {% set ns.count = ns.count + 1 %}
     <section id="stress-tests">
+        <div style="float: right;">
+            {% set stress_ns = namespace(worst='PASS') %}
+            {% for s in stress_tests.scenarios %}{% if s.outcome == 'FAIL' %}{% set stress_ns.worst = 'FAIL' %}{% endif %}{% endfor %}
+            <span class="badge {% if stress_ns.worst == 'FAIL' %}badge-critical{% else %}badge-stable{% endif %}">
+                RESILIENCE: {{ stress_ns.worst }}
+            </span>
+        </div>
         <h2>{{ ns.count }}. Stress Test Outcomes</h2>
         <div class="score-container">
             <span>Resilience Score:</span>
@@ -322,6 +330,11 @@
     {% if hyperparameter_robustness %}
     {% set ns.count = ns.count + 1 %}
     <section id="hyperparameter-robustness">
+        <div style="float: right;">
+            <span class="badge {% if hyperparameter_robustness.stability_score > 80 %}badge-stable{% elif hyperparameter_robustness.stability_score > 60 %}badge-warning{% else %}badge-critical{% endif %}">
+                STABILITY: {{ hyperparameter_robustness.stability_score }}%
+            </span>
+        </div>
         <h2>{{ ns.count }}. Hyperparameter Robustness</h2>
         <div class="score-container">
             <span>Stability Score:</span>
@@ -456,6 +469,16 @@
     {% if model_drift %}
     {% set ns.count = ns.count + 1 %}
     <section id="model-drift">
+        <div style="float: right;">
+            {% set drift_ns = namespace(worst='STABLE') %}
+            {% for m in model_drift.metrics %}
+                {% if m.status == 'CRITICAL' %}{% set drift_ns.worst = 'CRITICAL' %}
+                {% elif m.status == 'WARNING' and drift_ns.worst != 'CRITICAL' %}{% set drift_ns.worst = 'WARNING' %}{% endif %}
+            {% endfor %}
+            <span class="badge {% if drift_ns.worst == 'CRITICAL' %}badge-critical{% elif drift_ns.worst == 'WARNING' %}badge-warning{% else %}badge-stable{% endif %}">
+                DRIFT: {{ drift_ns.worst }}
+            </span>
+        </div>
         <h2>{{ ns.count }}. Model Drift Observations</h2>
         <table>
             <thead>
@@ -694,6 +717,11 @@
     {% if execution_quality %}
     {% set ns.count = ns.count + 1 %}
     <section id="execution-quality">
+        <div style="float: right;">
+            <span class="badge {% if execution_quality.efficiency_score > 90 %}badge-stable{% elif execution_quality.efficiency_score > 75 %}badge-warning{% else %}badge-critical{% endif %}">
+                EFFICIENCY: {{ execution_quality.efficiency_score|round(1) }}%
+            </span>
+        </div>
         <h2>{{ ns.count }}. Execution Quality & Alpha Decay</h2>
         <div class="score-container">
             <span>Execution Efficiency:</span>

--- a/tests/test_reporting_pydantic_fix.py
+++ b/tests/test_reporting_pydantic_fix.py
@@ -1,0 +1,14 @@
+from datetime import datetime, UTC
+from src.research.reporting import ResearchReport
+
+def test_research_report_instantiation():
+    """Verify ResearchReport can be instantiated with required fields."""
+    report = ResearchReport(
+        title="CI Fix Test",
+        executive_summary="Summary",
+        conclusion="Conclusion"
+    )
+    assert report.title == "CI Fix Test"
+    assert report.executive_summary == "Summary"
+    assert report.conclusion == "Conclusion"
+    assert isinstance(report.timestamp, datetime)


### PR DESCRIPTION
This submission fixes critical structural bugs in the research reporting Pydantic models that were preventing instantiation due to incorrect field ordering. It also significantly improves the institutional-grade HTML research reports by adding scannable status badges for key analytical dimensions (Resilience, Model Drift, Parameter Stability, and Execution Efficiency), utilizing Jinja2 namespace objects to ensure correct state propagation across loops. All reporting sections have been verified for integrity and scannability.

---
*PR created automatically by Jules for task [13590796127590303336](https://jules.google.com/task/13590796127590303336) started by @saysgrok*