### PR TITLE
Institutional Cost Modeling and Attribution for StressLab

### DIFF
--- a/docs/research/STRESS_LAB.md
+++ b/docs/research/STRESS_LAB.md
@@ -23,6 +23,8 @@ Each stress test generates a comprehensive report including:
 - **Breaking Points**: Identifies the exact level of friction (e.g., number of delay steps) where a strategy becomes unprofitable.
 - **Alpha Decay Metrics**: Calculates quantitative degradation slopes (e.g., return loss in bps per bp of slippage) derived from sensitivity analysis.
 - **Institutional Metrics**: Tracks Profit Factor (PF) and Recovery Factor across all scenarios.
+- **Cost Attribution**: Tracks total commission costs and slippage impact (in currency units) for granular performance degradation analysis.
+- **Financial Modeling**: Incorporates per-lot commissions (defaulting to 7.0 per lot) into both realized P&L and unrealized mark-to-market equity.
 - **Hardened Analytics**: Implements robust decay calculations for Sharpe and Sortino ratios, handling negative or near-zero baselines with absolute scaling and outlier clipping for enterprise stability.
 
 ## Usage

--- a/src/core/explainability.py
+++ b/src/core/explainability.py
@@ -30,7 +30,6 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
-from enum import IntEnum
 from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, ConfigDict, Field

--- a/src/research/stress_lab.py
+++ b/src/research/stress_lab.py
@@ -87,6 +87,7 @@ class StressScenario(BaseModel):
 
     # Configuration overrides
     lot_size: float = 0.1
+    commission_per_lot: float = 7.0  # Matches BacktestEngine default
     seed: int = 42
 
 
@@ -121,6 +122,8 @@ class StressTestMetrics(BaseModel):
     execution_quality_score: float  # 0.0 to 1.0
     latency_impact: float  # Percentage impact of delays
     max_slippage_experienced: float = 0.0  # Max bps of slippage seen
+    total_commission_cost: float = 0.0
+    total_slippage_cost: float = 0.0
     sortino_ratio: float = 0.0
 
 
@@ -221,16 +224,17 @@ class StressLab:
         data: pd.DataFrame,
         initial_balance: float = 10000.0,
         contract_multiplier: float = 100.0,  # Default for XAUUSD
+        commission_per_lot: float = 7.0,
     ):
         self.strategy = strategy
         self.data = data.copy()
         self.initial_balance = initial_balance
         self.contract_multiplier = contract_multiplier
+        self.commission_per_lot = commission_per_lot
         self.results: dict[str, StressTestMetrics] = {}
         self.sensitivity_data: dict[str, list[tuple[float, float]]] = {}
 
-    @staticmethod
-    def create_execution_hell_scenario() -> StressScenario:
+    def create_execution_hell_scenario(self) -> StressScenario:
         """Create a scenario with high slippage, wide spreads, and delays."""
         return StressScenario(
             name="Execution Hell",
@@ -245,10 +249,10 @@ class StressLab:
             execution_delay_steps=3,
             execution_delay_jitter=2,
             service_failure_prob=0.05,
+            commission_per_lot=self.commission_per_lot,
         )
 
-    @staticmethod
-    def create_liquidity_crisis_scenario() -> StressScenario:
+    def create_liquidity_crisis_scenario(self) -> StressScenario:
         """Create a scenario with missing data and extreme choppy price action."""
         return StressScenario(
             name="Liquidity Crisis",
@@ -260,10 +264,10 @@ class StressLab:
             spread_multiplier=2.5,
             spread_spike_prob=0.05,
             spread_spike_magnitude=1.0,
+            commission_per_lot=self.commission_per_lot,
         )
 
-    @staticmethod
-    def create_regime_shock_scenario() -> StressScenario:
+    def create_regime_shock_scenario(self) -> StressScenario:
         """Create a scenario with frequent and violent regime transitions."""
         return StressScenario(
             name="Regime Shock",
@@ -271,10 +275,10 @@ class StressLab:
             severity=StressSeverity.HIGH,
             regime_flip_prob=0.1,
             choppy_breakout_prob=0.05,
+            commission_per_lot=self.commission_per_lot,
         )
 
-    @staticmethod
-    def create_flash_crash_scenario() -> StressScenario:
+    def create_flash_crash_scenario(self) -> StressScenario:
         """Create a scenario with a violent flash crash event."""
         return StressScenario(
             name="Flash Crash",
@@ -285,10 +289,10 @@ class StressLab:
             slippage_spike_prob=0.2,
             slippage_spike_magnitude_bps=200.0,
             spread_multiplier=5.0,
+            commission_per_lot=self.commission_per_lot,
         )
 
-    @staticmethod
-    def create_data_freeze_scenario() -> StressScenario:
+    def create_data_freeze_scenario(self) -> StressScenario:
         """Create a scenario with prolonged stale price data (API/Feed freeze)."""
         return StressScenario(
             name="Data Freeze",
@@ -297,6 +301,7 @@ class StressLab:
             stale_data_prob=0.8,
             missing_tick_prob=0.1,
             spread_multiplier=1.5,
+            commission_per_lot=self.commission_per_lot,
         )
 
     def run_standard_suite(self, baseline_metrics: StressTestMetrics) -> ResilienceReport:
@@ -353,6 +358,7 @@ class StressLab:
             scenario = StressScenario(
                 name=f"Sensitivity_{parameter}_{val_str}",
                 description=f"Sensitivity test for {parameter} at {val_str}",
+                commission_per_lot=self.commission_per_lot,
             )
             setattr(scenario, parameter, val)
             metrics = self.run_scenario(scenario)
@@ -778,6 +784,8 @@ class StressLab:
         rng = np.random.default_rng(scenario.seed)
         latency_hits = 0
         max_slippage = 0.0
+        total_commission = 0.0
+        total_slippage = 0.0
 
         for i in range(1, n):
             # 1. Determine signal with delay and jitter
@@ -815,19 +823,31 @@ class StressLab:
             # Exit existing position if signal changed or is zero
             if position == 1 and current_sig != 1:
                 exit_price = current_price - (current_spread / 2) - slippage
-                pnl = (exit_price - entry_price) * lot_size * contract_multiplier
+                raw_pnl = (exit_price - entry_price) * lot_size * contract_multiplier
+                commission = lot_size * scenario.commission_per_lot
+                total_commission += commission
+                total_slippage += slippage * lot_size * contract_multiplier
+
+                pnl = raw_pnl - commission
                 trade_pnls.append(pnl)
                 cash += pnl
                 position = 0
             elif position == -1 and current_sig != -1:
                 exit_price = current_price + (current_spread / 2) + slippage
-                pnl = (entry_price - exit_price) * lot_size * contract_multiplier
+                raw_pnl = (entry_price - exit_price) * lot_size * contract_multiplier
+                commission = lot_size * scenario.commission_per_lot
+                total_commission += commission
+                total_slippage += slippage * lot_size * contract_multiplier
+
+                pnl = raw_pnl - commission
                 trade_pnls.append(pnl)
                 cash += pnl
                 position = 0
 
             # Open new position if signal is non-zero
             if position == 0 and current_sig != 0:
+                total_slippage += slippage * lot_size * contract_multiplier
+
                 if current_sig == 1:
                     position = 1
                     entry_price = current_price + (current_spread / 2) + slippage
@@ -835,17 +855,18 @@ class StressLab:
                     position = -1
                     entry_price = current_price - (current_spread / 2) - slippage
 
-            # Update Equity (Mark-to-Market including potential exit cost)
+            # Update Equity (Mark-to-Market including potential exit cost and commission)
             exit_cost = (current_spread / 2) + slippage
+            commission = lot_size * scenario.commission_per_lot
             if position == 1:
                 unrealized = (
                     ((current_price - exit_cost) - entry_price) * lot_size * contract_multiplier
-                )
+                ) - commission
                 equity[i] = cash + unrealized
             elif position == -1:
                 unrealized = (
                     (entry_price - (current_price + exit_cost)) * lot_size * contract_multiplier
-                )
+                ) - commission
                 equity[i] = cash + unrealized
             else:
                 equity[i] = cash
@@ -896,5 +917,7 @@ class StressLab:
             execution_quality_score=1.0 - (latency_hits / n),
             latency_impact=latency_hits / n,
             max_slippage_experienced=max_slippage,
+            total_commission_cost=total_commission,
+            total_slippage_cost=total_slippage,
             sortino_ratio=sortino,
         )

--- a/tests/test_stress_lab.py
+++ b/tests/test_stress_lab.py
@@ -232,16 +232,18 @@ def test_execution_delay_jitter(sample_data):
         assert fixed_metrics.total_return != jitter_metrics.total_return
 
 
-def test_factory_methods():
-    hell = StressLab.create_execution_hell_scenario()
+def test_factory_methods(sample_data):
+    strategy = EMACrossoverStrategy()
+    lab = StressLab(strategy, sample_data)
+    hell = lab.create_execution_hell_scenario()
     assert hell.name == "Execution Hell"
     assert hell.slippage_spike_prob > 0
 
-    crisis = StressLab.create_liquidity_crisis_scenario()
+    crisis = lab.create_liquidity_crisis_scenario()
     assert crisis.name == "Liquidity Crisis"
     assert crisis.missing_tick_prob > 0
 
-    shock = StressLab.create_regime_shock_scenario()
+    shock = lab.create_regime_shock_scenario()
     assert shock.name == "Regime Shock"
     assert shock.regime_flip_prob > 0
 
@@ -314,7 +316,7 @@ def test_backtest_pnl_accuracy(sample_data):
 def test_flash_crash_scenario(sample_data):
     strategy = EMACrossoverStrategy()
     lab = StressLab(strategy, sample_data)
-    scenario = StressLab.create_flash_crash_scenario()
+    scenario = lab.create_flash_crash_scenario()
 
     perturbed = lab._apply_perturbations(sample_data, scenario)
     # Flash crash should significantly lower the minimum 'low' price
@@ -655,3 +657,67 @@ def test_immediate_reversal_logic(sample_data):
     # Bar 3: Closes Long (opened Bar 2, as signals[3] is 0)
     # Total 3 trades in metrics.num_trades
     assert metrics.num_trades == 3
+
+
+def test_commission_deduction(sample_data):
+    """Verify that commissions are correctly deducted from net P&L and recorded."""
+    strategy = EMACrossoverStrategy()
+    # Use a high commission to make impact obvious
+    comm_per_lot = 100.0
+    lab = StressLab(strategy, sample_data, commission_per_lot=comm_per_lot)
+
+    # 1. Run with high commission
+    high_comm_scenario = lab.create_execution_hell_scenario()
+    high_comm_scenario.commission_per_lot = comm_per_lot
+    metrics_high = lab.run_scenario(high_comm_scenario)
+
+    # 2. Run with zero commission
+    zero_comm_scenario = lab.create_execution_hell_scenario()
+    zero_comm_scenario.commission_per_lot = 0.0
+    metrics_zero = lab.run_scenario(zero_comm_scenario)
+
+    if metrics_zero.num_trades > 0:
+        # Total return should be lower with high commission
+        assert metrics_high.total_return < metrics_zero.total_return
+        # total_commission_cost should match trades * lot_size * comm_per_lot
+        # Wait, opening and closing both might have commissions?
+        # In our implementation:
+        # Close: commission = lot_size * scenario.commission_per_lot
+        # Total cost is accumulated.
+
+        # Actually our implementation accumulates commission only on CLOSE of a trade
+        # (and during force close).
+        expected_comm = metrics_high.num_trades * high_comm_scenario.lot_size * comm_per_lot
+        assert np.isclose(metrics_high.total_commission_cost, expected_comm)
+
+
+def test_slippage_cost_tracking(sample_data):
+    """Verify that total_slippage_cost is correctly accumulated across trades."""
+    strategy = EMACrossoverStrategy()
+    lab = StressLab(strategy, sample_data)
+
+    # Force high slippage
+    scenario = lab.create_execution_hell_scenario()
+    scenario.slippage_bps = 100.0  # 1% slippage
+    scenario.slippage_spike_prob = 0.0
+
+    metrics = lab.run_scenario(scenario)
+
+    if metrics.num_trades > 0:
+        # total_slippage_cost should be > 0
+        assert metrics.total_slippage_cost > 0
+
+        # Each trade has slippage at ENTRY and EXIT in StressLab._backtest_with_stress
+        # In the loop:
+        # Entry: total_slippage += slippage * lot_size * contract_multiplier
+        # Exit: total_slippage += slippage * lot_size * contract_multiplier
+
+        # Approximate check: slippage * trades * lot_size * contract_multiplier * 2
+        # Note: 'slippage' in bps is price * 100 / 10000 = price * 0.01
+        avg_price = sample_data["close"].mean()
+        expected_slippage_per_leg = avg_price * (100.0 / 10000.0) * scenario.lot_size * lab.contract_multiplier
+        total_legs = metrics.num_trades * 2
+        expected_total = expected_slippage_per_leg * total_legs
+
+        # Since price varies, we use a wide tolerance or check more strictly
+        assert np.isclose(metrics.total_slippage_cost, expected_total, rtol=0.2)


### PR DESCRIPTION
This PR enhances the `StressLab` resilience testing framework with institutional-grade financial modeling. Key improvements include:

1.  **Commission Support:** The stress backtest loop now subtracts `commission_per_lot` (matching the project's `BacktestEngine` default of 7.0) from both realized P&L and unrealized equity tracking.
2.  **Granular Cost Attribution:** `StressTestMetrics` now includes `total_commission_cost` and `total_slippage_cost`, facilitating deeper analysis of how execution friction degrades strategy alpha.
3.  **Refined Scenario Generation:** Factory methods for standard scenarios (e.g., Execution Hell, Liquidity Crisis) were converted to instance methods to ensure the laboratory's configured commission rates are correctly propagated to generated scenarios.
4.  **Enhanced Test Coverage:** The unit test suite was expanded to 31 tests, including new cases for commission impact verification and slippage accumulation accuracy.

These changes ensure that stress testing provides a realistic assessment of strategy resilience under institutional trading conditions.

---
*PR created automatically by Jules for task [2011732634973687598](https://jules.google.com/task/2011732634973687598) started by @saysgrok*