### PR TITLE
refine institutional decision support system

### DIFF
--- a/src/core/decision_support.py
+++ b/src/core/decision_support.py
@@ -108,6 +108,18 @@ class PerformanceContext(BaseModel):
         le=0.0,
         description="Conditional Value at Risk (Expected Shortfall) at 95% confidence.",
     )
+    trade_frequency: float = Field(
+        0.0, ge=0.0, description="Average number of trades per day."
+    )
+    avg_hold_time: float = Field(
+        0.0, ge=0.0, description="Average trade duration in hours."
+    )
+    profit_concentration: float = Field(
+        0.0,
+        ge=0.0,
+        le=1.0,
+        description="Percentage of total profit from top 10% of trades (0.0 to 1.0).",
+    )
     total_trades: int = Field(0, ge=0, description="Count of trades analyzed in this window.")
 
 
@@ -272,6 +284,9 @@ class DecisionSupportSystem:
             sqn=performance_metrics.get("sqn", 0.0),
             max_drawdown=performance_metrics.get("max_drawdown", 0.0),
             cvar_95=performance_metrics.get("cvar_95", 0.0),
+            trade_frequency=performance_metrics.get("trade_frequency", 0.0),
+            avg_hold_time=performance_metrics.get("avg_hold_time", 0.0),
+            profit_concentration=performance_metrics.get("profit_concentration", 0.0),
             total_trades=int(performance_metrics.get("total_trades", 0)),
         )
 
@@ -377,7 +392,10 @@ class DecisionSupportSystem:
         consensus_score = consensus_strength * 40.0
 
         # 2. Regime Score (0-30)
-        regime_score = regime.confidence * 30.0
+        # Refinement: Average regime confidence with strategy-specific alignment
+        regime_score = (
+            (regime.confidence + explanation.regime_context.regime_alignment_score) / 2.0
+        ) * 30.0
 
         # 3. Risk & Safety Score (0-30)
         # Weights: 20% for Risk/Reward quality, 10% for Macro safety
@@ -634,7 +652,10 @@ class DecisionSupportSystem:
                 f"🎯 Win Rate:      [bold {wr_color}]{packet.performance.win_rate:.1%}[/]  |  "
                 f"🔢 Trades: {packet.performance.total_trades}\n"
                 f"💎 SQN Score:     [bold {sqn_color}]{packet.performance.sqn:.2f}[/]  |  "
-                f"📉 CVaR(95): [bold {cvar_color}]{packet.performance.cvar_95:.2%}[/]"
+                f"📉 CVaR(95): [bold {cvar_color}]{packet.performance.cvar_95:.2%}[/]\n"
+                f"🕒 Avg Hold:     [bold]{packet.performance.avg_hold_time:.1f}h[/]  |  "
+                f"🔄 Freq: [bold]{packet.performance.trade_frequency:.1f} t/d[/]\n"
+                f"🎯 Concentration: [bold]{packet.performance.profit_concentration:.1%}[/]"
             )
             perf_panel = Panel(perf_content, title="📊 Recent Performance", border_style="magenta")
 
@@ -726,6 +747,9 @@ class DecisionSupportSystem:
                 f"RF {packet.performance.recovery_factor:.2f} | "
                 f"Win% {packet.performance.win_rate:.1%} | "
                 f"W/L {packet.performance.win_loss_ratio:.2f}\n"
+                f"            Hold: {packet.performance.avg_hold_time:.1f}h | "
+                f"Freq: {packet.performance.trade_frequency:.1f} t/d | "
+                f"Conc: {packet.performance.profit_concentration:.1%}\n"
             )
             res += f"MACRO: {'BLOCKED' if packet.macro_risk.is_blocked else 'OK'} (Insight: {packet.macro_risk.reason})\n"
 

--- a/tests/test_decision_support.py
+++ b/tests/test_decision_support.py
@@ -81,6 +81,9 @@ def test_assemble_packet_full_approval(mock_explanation, mock_regime, mock_macro
         "max_drawdown": 0.05,
         "win_rate": 0.6,
         "win_loss_ratio": 1.8,
+        "trade_frequency": 5.0,
+        "avg_hold_time": 2.5,
+        "profit_concentration": 0.15,
         "total_trades": 100,
     }
 
@@ -106,6 +109,9 @@ def test_assemble_packet_full_approval(mock_explanation, mock_regime, mock_macro
     assert packet.performance.sharpe_ratio == 1.5
     assert packet.performance.recovery_factor == 3.2
     assert packet.performance.win_loss_ratio == 1.8
+    assert packet.performance.trade_frequency == 5.0
+    assert packet.performance.avg_hold_time == 2.5
+    assert packet.performance.profit_concentration == 0.15
     assert packet.performance.total_trades == 100
     assert packet.performance.calmar_ratio == 0.0  # Default if not in metrics
 
@@ -121,16 +127,18 @@ def test_assemble_packet_full_approval(mock_explanation, mock_regime, mock_macro
 def test_decision_augmentation_logic(mock_explanation, mock_regime, mock_macro_risk):
     dss = DecisionSupportSystem()
 
-    # 1. High Confidence Case (Unanimous, High Regime Confidence, Good RR)
+    # 1. High Confidence Case (Unanimous, High Regime Confidence, High Alignment, Good RR)
     mock_explanation.model_attributions = [
         ModelAttribution(model_name="M1", vote=SignalDirection.BUY, confidence=0.9, weight=1.0)
     ]
     mock_explanation.risk_assessment.risk_reward_ratio = 3.0
     mock_regime = mock_regime.model_copy(update={"confidence": 1.0})
+    mock_explanation.regime_context.regime_alignment_score = 1.0
     mock_macro_risk = mock_macro_risk.model_copy(update={"risk_multiplier": 1.0})
 
     packet = dss.assemble_packet("XAUUSD", mock_explanation, mock_regime, mock_macro_risk, {})
-    assert packet.decision_score == 100.0  # (1.0*40) + (1.0*30) + (20 + 10)
+    # Consensus: 40, Regime: ((1.0+1.0)/2)*30=30, Risk: 20+10=30 -> 100
+    assert packet.decision_score == 100.0
     assert packet.status_level == DecisionStatus.EXECUTE
     assert packet.consensus_score == 40.0
     assert packet.regime_score == 30.0
@@ -142,11 +150,12 @@ def test_decision_augmentation_logic(mock_explanation, mock_regime, mock_macro_r
         ModelAttribution(model_name="M1", vote=SignalDirection.BUY, confidence=0.8, weight=1.0)
     ]
     mock_regime = mock_regime.model_copy(update={"confidence": 0.5})
+    mock_explanation.regime_context.regime_alignment_score = 0.5
     mock_explanation.risk_assessment.risk_reward_ratio = 2.0  # (2/3)*20 = 13.33
     mock_macro_risk = mock_macro_risk.model_copy(update={"risk_multiplier": 0.8})
 
     # Consensus score: 1.0 * 40 = 40
-    # Regime score: 0.5 * 30 = 15
+    # Regime score: ((0.5+0.5)/2) * 30 = 15
     # Risk score: 13.33 + 8 = 21.33
     # Total ~ 76.33
     packet = dss.assemble_packet("XAUUSD", mock_explanation, mock_regime, mock_macro_risk, {})
@@ -174,6 +183,7 @@ def test_decision_augmentation_logic(mock_explanation, mock_regime, mock_macro_r
 
     # 3. Blocked Case
     mock_explanation.risk_assessment.passed = False
+    mock_explanation.regime_context.regime_alignment_score = 0.85
     packet = dss.assemble_packet("XAUUSD", mock_explanation, mock_regime, mock_macro_risk, {})
     assert packet.status_level == DecisionStatus.BLOCKED
     assert packet.sizing_multiplier == 0.0
@@ -188,11 +198,14 @@ def test_decision_augmentation_logic(mock_explanation, mock_regime, mock_macro_r
     mock_macro_risk = mock_macro_risk.model_copy(update={"risk_multiplier": 0.25})
 
     packet = dss.assemble_packet("XAUUSD", mock_explanation, mock_regime, mock_macro_risk, {})
-    # Score: 40 (Consensus) + 30 (Regime) + 20 (R:R) + 2.5 (Macro Safety) = 92.5
-    assert packet.decision_score == 92.5
+    # Consensus: 40
+    # Regime: ((1.0+0.85)/2)*30 = 0.925*30 = 27.75
+    # Risk: 20 (RR) + 2.5 (Macro Safety) = 22.5
+    # Total: 40 + 27.75 + 22.5 = 90.25
+    assert packet.decision_score == 90.25
     assert packet.status_level == DecisionStatus.EXECUTE
-    # Sizing: (0.925^1.5) * 1.0 (EXECUTE) * 0.25 (Macro)
-    expected_sizing = (0.925**1.5) * 0.25
+    # Sizing: (0.9025^1.5) * 1.0 (EXECUTE) * 0.25 (Macro)
+    expected_sizing = (0.9025**1.5) * 0.25
     assert abs(packet.sizing_multiplier - expected_sizing) < 1e-6
 
 
@@ -421,6 +434,7 @@ def test_high_conviction_labeling(mock_explanation, mock_regime, mock_macro_risk
     ]
     mock_explanation.risk_assessment.risk_reward_ratio = 3.0
     mock_regime = mock_regime.model_copy(update={"confidence": 1.0})
+    mock_explanation.regime_context.regime_alignment_score = 1.0
     mock_macro_risk = mock_macro_risk.model_copy(update={"risk_multiplier": 1.0})
 
     packet = dss.assemble_packet("XAUUSD", mock_explanation, mock_regime, mock_macro_risk, {})
@@ -453,12 +467,22 @@ def test_review_status_assignment(mock_explanation, mock_regime, mock_macro_risk
     ]
     # Reduce regime confidence to lower the score
     mock_regime = mock_regime.model_copy(update={"confidence": 0.4})
+    mock_explanation.regime_context.regime_alignment_score = 0.5
 
-    # Score will be around 40*1.0 + 30*0.4 + 23.33 = 40 + 12 + 23.33 = 75.33
+    # Score: 40 (consensus) + ((0.4+0.5)/2)*30=13.5 + (20+10)*0.8(macro)=24? No
+    # Consensus: 1.0 * 40 = 40
+    # Regime: 0.45 * 30 = 13.5
+    # Risk: 20 (RR 2.0) + 10 (Macro 1.0) = 30
+    # Total: 40 + 13.5 + 30 = 83.5 -> Still EXECUTE.
+
+    # Let's lower it more.
+    mock_explanation.risk_assessment.risk_reward_ratio = 1.0 # (1/3)*20 = 6.66
+    # Total: 40 + 13.5 + 6.66 + 10 = 70.16
+
     packet = dss.assemble_packet("XAUUSD", mock_explanation, mock_regime, mock_macro_risk, {})
 
     assert packet.is_executable is True
-    assert 60.0 <= packet.decision_score < 80.0
+    assert 70.0 <= packet.decision_score < 80.0
     assert packet.requires_review is True
     assert packet.status_level == DecisionStatus.REVIEW
 
@@ -473,6 +497,9 @@ def test_packet_serialization_completeness(mock_explanation, mock_regime, mock_m
         "recovery_factor": 3.1,
         "sqn": 4.2,
         "cvar_95": -0.015,
+        "trade_frequency": 4.5,
+        "avg_hold_time": 3.2,
+        "profit_concentration": 0.22,
     }
 
     packet = dss.assemble_packet(
@@ -487,12 +514,18 @@ def test_packet_serialization_completeness(mock_explanation, mock_regime, mock_m
     assert packet.performance.sortino_ratio == 2.5
     assert packet.performance.sqn == 4.2
     assert packet.performance.cvar_95 == -0.015
+    assert packet.performance.trade_frequency == 4.5
+    assert packet.performance.avg_hold_time == 3.2
+    assert packet.performance.profit_concentration == 0.22
 
     # Check dict export
     data = packet.model_dump()
     assert data["performance"]["sortino_ratio"] == 2.5
     assert data["performance"]["sqn"] == 4.2
     assert data["performance"]["cvar_95"] == -0.015
+    assert data["performance"]["trade_frequency"] == 4.5
+    assert data["performance"]["avg_hold_time"] == 3.2
+    assert data["performance"]["profit_concentration"] == 0.22
 
 
 def test_packet_immutability():
@@ -559,6 +592,7 @@ def test_extreme_decision_scores(mock_explanation, mock_regime, mock_macro_risk)
     ]
     mock_explanation.risk_assessment.risk_reward_ratio = 0.0
     mock_regime = mock_regime.model_copy(update={"confidence": 0.0})
+    mock_explanation.regime_context.regime_alignment_score = 0.0
     mock_macro_risk = mock_macro_risk.model_copy(update={"risk_multiplier": 0.0})
 
     packet_min = dss.assemble_packet("XAUUSD", mock_explanation, mock_regime, mock_macro_risk, {})
@@ -572,6 +606,7 @@ def test_extreme_decision_scores(mock_explanation, mock_regime, mock_macro_risk)
     ]
     mock_explanation.risk_assessment.risk_reward_ratio = 5.0  # (5/3) clamped to 1.0 -> 20pts
     mock_regime = mock_regime.model_copy(update={"confidence": 1.0})
+    mock_explanation.regime_context.regime_alignment_score = 1.0
     mock_macro_risk = mock_macro_risk.model_copy(update={"risk_multiplier": 1.0})
 
     packet_max = dss.assemble_packet("XAUUSD", mock_explanation, mock_regime, mock_macro_risk, {})
@@ -662,6 +697,7 @@ def test_sizing_multiplier_scaling(mock_explanation, mock_regime, mock_macro_ris
     ]
     mock_explanation.risk_assessment.risk_reward_ratio = 3.0
     mock_regime = mock_regime.model_copy(update={"confidence": 1.0})
+    mock_explanation.regime_context.regime_alignment_score = 1.0
     mock_macro_risk = mock_macro_risk.model_copy(update={"risk_multiplier": 1.0})
 
     packet_100 = dss.assemble_packet("XAUUSD", mock_explanation, mock_regime, mock_macro_risk, {})
@@ -675,10 +711,11 @@ def test_sizing_multiplier_scaling(mock_explanation, mock_regime, mock_macro_ris
         ModelAttribution(model_name="M2", vote=SignalDirection.SELL, confidence=0.5, weight=0.5),
     ]
     # Consensus score: (0.5/1.0) * 40 = 20
-    # Regime score: 0.5 * 30 = 15
+    # Regime score: ((0.5+0.5)/2) * 30 = 15
     # Risk score: (1.5/3)*20 + 0.5*10 = 10 + 5 = 15
     # Total = 20 + 15 + 15 = 50
     mock_regime = mock_regime.model_copy(update={"confidence": 0.5})
+    mock_explanation.regime_context.regime_alignment_score = 0.5
     mock_explanation.risk_assessment.risk_reward_ratio = 1.5
     mock_macro_risk = mock_macro_risk.model_copy(update={"risk_multiplier": 0.5})
 

--- a/tests/test_decision_support_v2.py
+++ b/tests/test_decision_support_v2.py
@@ -44,7 +44,7 @@ def base_explanation():
         ],
         feature_contributions=[],
         risk_assessment=RiskAssessment(passed=True, risk_reward_ratio=2.5, summary="Good R:R"),
-        regime_context=RegimeContext(regime_name="Trending", confidence=0.9, is_favorable=True),
+        regime_context=RegimeContext(regime_name="Trending", confidence=0.9, is_favorable=True, regime_alignment_score=0.9),
         human_readable_summary="Signal shows momentum alignment.",
         machine_attribution={}
     )
@@ -70,7 +70,10 @@ def test_executive_summary_generation(dss, base_explanation, base_regime, base_m
     packet = dss.assemble_packet("XAUUSD", base_explanation, base_regime, base_macro, {})
     assert packet.status_level == DecisionStatus.EXECUTE
     assert "maximum confluence" in packet.executive_summary.lower()
-    # Score: (1.0*40) + (0.9*30) + (min(2.5/3, 1)*20 + 10) = 40+27+16.66+10 = 93.66 -> 93.7
+    # Consensus: 40
+    # Regime: ((0.9+0.9)/2)*30 = 27
+    # Risk: 16.66 + 10 = 26.66
+    # Total: 40 + 27 + 26.66 = 93.66 -> 93.7
     assert "93.7" in packet.executive_summary
 
     # 2. BLOCKED state
@@ -93,16 +96,35 @@ def test_review_flag_logic(dss, base_explanation, base_regime, base_macro):
 
     # 2. Lower score (75) - Review Required (even if REVIEW)
     low_conf_regime = base_regime.model_copy(update={"confidence": 0.4})
-    # Score: 40 (consensus) + 12 (regime) + 16.6 (risk) + 10 (macro) = 78.6
-    packet_mid = dss.assemble_packet("XAUUSD", base_explanation, low_conf_regime, base_macro, {})
-    assert 78.0 < packet_mid.decision_score < 79.0
+    # Consensus: 40
+    # Regime Alignment Score in base_explanation: 0.9
+    # Regime: ((0.4+0.9)/2)*30 = 0.65*30 = 19.5
+    # Risk: 26.66
+    # Total: 40 + 19.5 + 26.66 = 86.16 -> still EXECUTE
+
+    # Lower it more
+    vlow_align_explanation = base_explanation.model_copy(update={
+        "regime_context": RegimeContext(regime_name="Trending", confidence=0.9, is_favorable=True, regime_alignment_score=0.2)
+    })
+    # Consensus: 40
+    # Regime: ((0.4+0.2)/2)*30 = 0.3*30 = 9
+    # Risk: 26.66
+    # Total: 40 + 9 + 26.66 = 75.66
+    packet_mid = dss.assemble_packet("XAUUSD", vlow_align_explanation, low_conf_regime, base_macro, {})
+    assert 75.0 < packet_mid.decision_score < 76.0
     assert packet_mid.status_level == DecisionStatus.REVIEW
     assert packet_mid.requires_review is True
 
     # 3. CAUTION status - Always review
     vlow_conf_regime = base_regime.model_copy(update={"confidence": 0.1})
-    # Score: 40 + 3 + 16.6 + 10 = 69.6 -> CAUTION
-    packet_caution = dss.assemble_packet("XAUUSD", base_explanation, vlow_conf_regime, base_macro, {})
+    # Consensus: 40, Regime: ((0.1+0.2)/2)*30 = 4.5, Risk: 26.66 -> 71.16?
+    # Let's lower RR to be sure
+    caution_explanation = vlow_align_explanation.model_copy(update={
+        "risk_assessment": RiskAssessment(passed=True, risk_reward_ratio=1.0, summary="Low R:R")
+    })
+    # Risk: (1/3)*20 + 10 = 16.66
+    # Total: 40 + 4.5 + 16.66 = 61.16
+    packet_caution = dss.assemble_packet("XAUUSD", caution_explanation, vlow_conf_regime, base_macro, {})
     assert packet_caution.status_level == DecisionStatus.CAUTION
     assert packet_caution.requires_review is True
 
@@ -110,8 +132,15 @@ def test_dashboard_formatting_enhancements(dss, base_explanation, base_regime, b
     """Verify that new visual elements appear in the dashboard output."""
 
     # Set to CAUTION to trigger [REVIEW REQUIRED]
+    # We use the caution_explanation from above logic or similar
+    vlow_align_explanation = base_explanation.model_copy(update={
+        "regime_context": RegimeContext(regime_name="Trending", confidence=0.9, is_favorable=True, regime_alignment_score=0.2)
+    })
+    caution_explanation = vlow_align_explanation.model_copy(update={
+        "risk_assessment": RiskAssessment(passed=True, risk_reward_ratio=1.0, summary="Low R:R")
+    })
     caution_regime = base_regime.model_copy(update={"confidence": 0.1})
-    packet = dss.assemble_packet("XAUUSD", base_explanation, caution_regime, base_macro, {})
+    packet = dss.assemble_packet("XAUUSD", caution_explanation, caution_regime, base_macro, {})
 
     output = dss.format_for_operator(packet)
     assert "REVIEW REQUIRED" in output


### PR DESCRIPTION
This PR refines the Decision Support System to meet institutional standards for XAUUSD trading. Key enhancements include:

1.  **Expanded Performance Analytics**: Added `trade_frequency`, `avg_hold_time`, and `profit_concentration` to the decision packet, providing operators with deeper context on strategy stability.
2.  **Sophisticated Regime Awareness**: The `regime_score` component of the decision score now averages raw regime confidence with the strategy-specific `regime_alignment_score`, ensuring that "high confidence" regimes that are "unfavorable" for the strategy correctly lower the final conviction.
3.  **Institutional UX**: Updated the terminal dashboard (`rich`-based) to display the new metrics with appropriate formatting and iconography.
4.  **Robust Validation**: Integrated these changes into the immutable Pydantic models and verified them with 23 unit tests covering edge cases and complex confluence scenarios.

---
*PR created automatically by Jules for task [14863980251247551831](https://jules.google.com/task/14863980251247551831) started by @saysgrok*