### PR TITLE
docs: enhance triage report resilience to API failures

### DIFF
--- a/scripts/generate_triage_report.py
+++ b/scripts/generate_triage_report.py
@@ -32,7 +32,11 @@ def get_all_prs():
     while True:
         url = f"https://api.github.com/repos/{REPO}/pulls?state=open&per_page=100&page={page}"
         data = api_call(url)
-        if data is None or not isinstance(data, list):
+        if data is None:
+            if page == 1:
+                return None  # Signal failure on first page
+            break
+        if not isinstance(data, list):
             break
         prs.extend(data)
         if len(data) < 100:
@@ -49,7 +53,9 @@ def get_all_pr_files(pr_number):
             f"https://api.github.com/repos/{REPO}/pulls/{pr_number}/files?per_page=100&page={page}"
         )
         data = api_call(url)
-        if data is None or not isinstance(data, list):
+        if data is None:
+            return None  # Signal failure
+        if not isinstance(data, list):
             break
         files.extend([f["filename"] for f in data if "filename" in f])
         if len(data) < 100:
@@ -223,11 +229,15 @@ def generate_report():
     print("Fetching PRs...")
     prs = get_all_prs()
 
-    if not prs and prs is not None:
+    if prs is None:
+        print(
+            "CRITICAL: Rate limited or error fetching PRs. Aborting report generation to preserve existing data.",
+            file=sys.stderr,
+        )
+        return
+
+    if not prs:
         print("No open PRs found.")
-    elif prs is None:
-        print("Rate limited or error fetching PRs.")
-        prs = []
 
     now = datetime.datetime.now(datetime.timezone.utc)
     now_str = now.strftime("%Y-%m-%d %H:%M:%S UTC")
@@ -256,12 +266,8 @@ def generate_report():
     # We will populate this later
 
     report += "## 📋 Summary Table\n\n"
-    report += (
-        "| PR # | Title | Author | Branch | Labels | CI Status | Risk Class | Status Flag |\n"
-    )
-    report += (
-        "|------|-------|--------|--------|--------|-----------|------------|-------------|\n"
-    )
+    report += "| PR # | Title | Author | Branch | Labels | CI Status | Risk Class | Status Flag |\n"
+    report += "|------|-------|--------|--------|--------|-----------|------------|-------------|\n"
 
     classified_prs = []
 
@@ -290,8 +296,13 @@ def generate_report():
         if i < detailed_limit:
             ci_status = get_ci_status(sha)
             files = get_all_pr_files(num)
-            risk, reason = classify_risk(files, title)
-            domains = get_domains(files)
+            if files is None:
+                print(f"Warning: Failed to fetch files for PR #{num}. Using heuristics.")
+                risk, reason = classify_risk([], title)
+                domains = ["Triage Required (API Error)"]
+            else:
+                risk, reason = classify_risk(files, title)
+                domains = get_domains(files)
         else:
             ci_status = "unknown"
             risk, reason = classify_risk([], title)
@@ -417,9 +428,7 @@ def generate_report():
             if "Stale" in c["flag"]:
                 status_note = " (Candidate for re-validation/review)"
 
-            checklist += (
-                f"- **Short scope summary**: {c['risk']} update implementing '{c['title']}'{status_note}\n"
-            )
+            checklist += f"- **Short scope summary**: {c['risk']} update implementing '{c['title']}'{status_note}\n"
             checklist += f"- **Domains touched**: {', '.join(c['domains'])}\n"
             checklist += f"- **CI status**: {c['ci_status']}\n"
 


### PR DESCRIPTION
Problem: The `scripts/generate_triage_report.py` script was overwriting the daily triage dashboard and merge-readiness checklist with empty data when encountering GitHub API rate limits. This resulted in a total loss of visibility into the PR backlog.

Root Cause: The script proceeded to open and write report files even after `urllib` calls returned `None` due to 403 errors, treating the lack of data as "no open PRs found".

Solution: 
1. Modified `get_all_prs` and `get_all_pr_files` to explicitly signal failure by returning `None` on the first page if the API call fails.
2. Updated `generate_report` to abort execution and print a critical warning if the initial PR fetch fails.
3. Added a warning and heuristic fallback if individual PR file fetching fails, preventing a single failure from blocking the entire report.

Impact: Prevents the destructive "wiping" of the triage dashboard during API downtime or rate-limiting events, ensuring persistent visibility for reviewers.

Validation: 
- Verified logic by inspection and execution in the sandbox (where it correctly detected rate limits and aborted).
- Ran `ruff format` and `ruff check` on the script.
- Confirmed no other files were modified in the final state.

Safety Check: Only documentation-generation scripts were modified. No trading logic, risk logic, or tests were touched.

Remaining Gaps: The script still relies on unauthenticated API calls in the sandbox, which are prone to rate limiting. Using a `GITHUB_TOKEN` would increase the limit.

---
*PR created automatically by Jules for task [1063976914732873390](https://jules.google.com/task/1063976914732873390) started by @triqbit*