### PR TITLE
docs: update daily merge-readiness checklist [2026-06-11]

### DIFF
--- a/docs/status/MERGE_READY_CHECKLIST.md
+++ b/docs/status/MERGE_READY_CHECKLIST.md
@@ -1,9 +1,9 @@
 # Merge-Readiness Checklist
 
 > [!IMPORTANT]
-> **Critical Repository State Notice:** The `main` branch is currently operating under a history-grafting model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `c24d6ce` is required for all PRs.**
+> **Critical Repository State Notice:** The `main` branch is currently operating under a history-grafting model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `e61fc1d` is required for all PRs.**
 
-Generated on: 2026-06-10 14:15:00 UTC
+Generated on: 2026-06-11 14:15:00 UTC
 
 This checklist identifies top promising PRs for immediate review.
 
@@ -11,21 +11,21 @@ This checklist identifies top promising PRs for immediate review.
 - **Short scope summary**: Updates documentation and setup scripts to improve the developer experience and onboarding process.
 - **Domains touched**: docs, infra/scripts
 - **CI status**: unknown (Stale relative to latest graft)
-- **Missing items**: Mandatory rebase against commit `c24d6ce`
+- **Missing items**: Mandatory rebase against commit `e61fc1d`
 - **Recommendation**: Candidate for detailed review once rebased.
 
 ## 2. PR #1300: 🧹 Jules05: Technical debt cleanup — architectural harmonization
 - **Short scope summary**: Core cleanup and architectural alignment across multiple modules to reduce technical debt.
 - **Domains touched**: core architecture, refactor
 - **CI status**: unknown (Stale relative to latest graft)
-- **Missing items**: Mandatory rebase against commit `c24d6ce`
+- **Missing items**: Mandatory rebase against commit `e61fc1d`
 - **Recommendation**: Candidate for review after rebase and validation.
 
-## 3. PR #1268: refactor: 🧹 Jules05: Technical debt cleanup — architectural harmonization
-- **Short scope summary**: Refactoring of architectural components to harmonize the system's design and improve maintainability.
-- **Domains touched**: refactor, core architecture
+## 3. PR #1210: docs: 📘 Jules02: Documentation and schema governance — Unified decision schemas and tracing
+- **Short scope summary**: Unifies decision schemas and implements tracing for better documentation and schema governance.
+- **Domains touched**: docs, schema governance
 - **CI status**: unknown (Stale relative to latest graft)
-- **Missing items**: Mandatory rebase against commit `c24d6ce`
+- **Missing items**: Mandatory rebase against commit `e61fc1d`
 - **Recommendation**: Candidate for review once rebase is confirmed.
 
 ---


### PR DESCRIPTION
Daily update of the merge-readiness checklist to assist Jules05 and human reviewers. Candidates selected from Safe Surface category in the latest triage report. Mandatory rebase against commit e61fc1d is specified.

---
*PR created automatically by Jules for task [3977739861775034309](https://jules.google.com/task/3977739861775034309) started by @triqbit*