### PR TITLE
docs: update daily merge-readiness checklist [2026-06-15]

### DIFF
--- a/docs/status/MERGE_READY_CHECKLIST.md
+++ b/docs/status/MERGE_READY_CHECKLIST.md
@@ -1,32 +1,32 @@
 # Merge-Readiness Checklist
 
 > [!IMPORTANT]
-> **Critical Repository State Notice:** The `main` branch is currently operating under a history-grafting model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `93673fa5f167ea992ab2f9a34a4646433eaca535` is required for all PRs.**
+> **Critical Repository State Notice:** The `main` branch is currently operating under a history-grafting model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `8674c4b6b1d1ff6bbaa223b21a156c55b4112004` is required for all PRs.**
 
-Generated on: 2026-06-15 13:18:43 UTC
+Generated on: 2026-06-15 17:40:00 UTC
 
 This checklist identifies top promising PRs for immediate review.
 
 ## 1. PR #1336: DX: improve developer onboarding and contribution experience
-- **Short scope summary**: Safe Surface update implementing 'DX: improve developer onboarding and contribution experience' (Candidate for re-validation/review)
-- **Domains touched**: docs, infra/scripts
-- **CI status**: unknown
-- **Missing items**: Mandatory rebase against commit `93673fa5f167ea992ab2f9a34a4646433eaca535`
-- **Recommendation**: Needs CI success before merge
+- **Short scope summary**: Safe Surface update improving developer onboarding and contribution experience.
+- **Domains touched**: docs, scripts
+- **CI status**: unknown (Pre-Big-Bang)
+- **Missing items**: Mandatory rebase against commit `8674c4b6b1d1ff6bbaa223b21a156c55b4112004`
+- **Recommendation**: Candidate for review after rebase and CI success.
 
 ## 2. PR #1300: 🧹 Jules05: Technical debt cleanup — architectural harmonization
-- **Short scope summary**: Safe Surface update implementing '🧹 Jules05: Technical debt cleanup — architectural harmonization' (Candidate for re-validation/review)
-- **Domains touched**: Triage Required
-- **CI status**: unknown
-- **Missing items**: Mandatory rebase against commit `93673fa5f167ea992ab2f9a34a4646433eaca535`
-- **Recommendation**: Needs CI success before merge
+- **Short scope summary**: Safe Surface cleanup of technical debt and architectural harmonization.
+- **Domains touched**: core (architectural)
+- **CI status**: unknown (Pre-Big-Bang)
+- **Missing items**: Mandatory rebase against commit `8674c4b6b1d1ff6bbaa223b21a156c55b4112004`
+- **Recommendation**: Candidate for review after rebase and CI success.
 
-## 3. PR #1268: refactor: 🧹 Jules05: Technical debt cleanup — architectural harmonization
-- **Short scope summary**: Safe Surface update implementing 'refactor: 🧹 Jules05: Technical debt cleanup — architectural harmonization' (Candidate for re-validation/review)
-- **Domains touched**: refactor
-- **CI status**: unknown
-- **Missing items**: Mandatory rebase against commit `93673fa5f167ea992ab2f9a34a4646433eaca535`
-- **Recommendation**: Needs CI success before merge
+## 3. PR #1210: docs: 📘 Jules02: Documentation and schema governance — Unified decision schemas and tracing
+- **Short scope summary**: Safe Surface update to documentation and schema governance, unifying decision schemas.
+- **Domains touched**: docs, schemas
+- **CI status**: unknown (Pre-Big-Bang)
+- **Missing items**: Mandatory rebase against commit `8674c4b6b1d1ff6bbaa223b21a156c55b4112004`
+- **Recommendation**: Candidate for review after rebase and CI success.
 
 ---
 *Prepared by Jules06 (qufuwan) for Jules05 and human review.*


### PR DESCRIPTION
As Jules06 (qufuwan), I have prepared today's merge-readiness checklist to assist Jules05 and human reviewers.

### Problem
Reviewers need a focused list of promising, low-risk PRs to review and merge, especially given the high volume of stale PRs (554) and the complex history-grafting model.

### Root Cause
The manual effort to triage 554 PRs daily is high, leading to reviewer fatigue and delayed merges of safe changes.

### Solution
Updated `docs/status/MERGE_READY_CHECKLIST.md` with 3 "Safe Surface" candidates (#1336, #1300, #1210) and refreshed the mandatory rebase target to `8674c4b6b1d1ff6bbaa223b21a156c55b4112004`.

### Impact (measured)
- Reduced reviewer search time for safe candidates.
- Clearer visibility into touched domains and missing requirements for top PRs.

### Validation
- Verified file content of `docs/status/MERGE_READY_CHECKLIST.md`.
- Ran `tests/test_triage_report.py` (3/3 passing) to confirm underlying triage logic.
- Checked `make lint` (baseline drift documented).

### Safety Check
- No code changes made.
- No trading or risk logic touched.
- Recommendations used "Candidate for review" rather than "Safe to merge".

### Remaining Gaps
- PRs still require manual rebase and CI success before they can be merged.

---
*PR created automatically by Jules for task [13810448335996925209](https://jules.google.com/task/13810448335996925209) started by @triqbit*