### PR TITLE
DX: update daily merge-readiness checklist [2026-06-19]

### DIFF
--- a/docs/status/MERGE_READY_CHECKLIST.md
+++ b/docs/status/MERGE_READY_CHECKLIST.md
@@ -1,32 +1,32 @@
 # Merge-Readiness Checklist
 
 > [!IMPORTANT]
-> **Critical Repository State Notice:** The `main` branch is currently operating under a history-grafting model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `1a18af0c8557d6e475f4ef96b2e515d7aabc8627` is required for all PRs.**
+> **Critical Repository State Notice:** The `main` branch is currently operating under a history-grafting model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `7089ac292d0c90785ccb3bab90bb28f226c1552f` is required for all PRs.**
 
-Generated on: 2026-06-19 13:12:53 UTC
+Generated on: 2026-06-19 14:20:00 UTC
 
 This checklist identifies top promising PRs for immediate review.
 
 ## 1. PR #1336: DX: improve developer onboarding and contribution experience
-- **Short scope summary**: Safe Surface update implementing 'DX: improve developer onboarding and contribution experience' (Candidate for re-validation/review)
+- **Short scope summary**: Safe Surface update implementing 'DX: improve developer onboarding and contribution experience' and dependency harmonization.
 - **Domains touched**: docs, infra/scripts
-- **CI status**: unknown
-- **Missing items**: Mandatory rebase against commit `1a18af0c8557d6e475f4ef96b2e515d7aabc8627`
+- **CI status**: unknown (Stale)
+- **Missing items**: Mandatory rebase against commit `7089ac292d0c90785ccb3bab90bb28f226c1552f`
 - **Recommendation**: Needs CI success before merge
 
 ## 2. PR #1300: 🧹 Jules05: Technical debt cleanup — architectural harmonization
-- **Short scope summary**: Safe Surface update implementing '🧹 Jules05: Technical debt cleanup — architectural harmonization' (Candidate for re-validation/review)
-- **Domains touched**: Triage Required
-- **CI status**: unknown
-- **Missing items**: Mandatory rebase against commit `1a18af0c8557d6e475f4ef96b2e515d7aabc8627`
-- **Recommendation**: Needs CI success before merge
+- **Short scope summary**: Safe Surface update implementing technical debt cleanup, consolidating RiskManager and relocating FeatureEngineer.
+- **Domains touched**: core trading, risk, refactor
+- **CI status**: unknown (Stale)
+- **Missing items**: Mandatory rebase against commit `7089ac292d0c90785ccb3bab90bb28f226c1552f`
+- **Recommendation**: Needs detailed domain expert review and CI success
 
 ## 3. PR #1268: refactor: 🧹 Jules05: Technical debt cleanup — architectural harmonization
-- **Short scope summary**: Safe Surface update implementing 'refactor: 🧹 Jules05: Technical debt cleanup — architectural harmonization' (Candidate for re-validation/review)
-- **Domains touched**: refactor
-- **CI status**: unknown
-- **Missing items**: Mandatory rebase against commit `1a18af0c8557d6e475f4ef96b2e515d7aabc8627`
-- **Recommendation**: Needs CI success before merge
+- **Short scope summary**: Safe Surface update implementing technical debt cleanup, consolidating 8-layer ATR risk logic and relocatig FeatureEngineer.
+- **Domains touched**: core trading, risk, refactor
+- **CI status**: unknown (Stale)
+- **Missing items**: Mandatory rebase against commit `7089ac292d0c90785ccb3bab90bb28f226c1552f`
+- **Recommendation**: Needs detailed domain expert review and CI success
 
 ---
 *Prepared by Jules06 (qufuwan) for Jules05 and human review.*

--- a/docs/status/PR_TRIAGE_DAILY.md
+++ b/docs/status/PR_TRIAGE_DAILY.md
@@ -1,6 +1,6 @@
 # Daily PR Triage Dashboard
 
-**Date:** 2026-06-19 13:12:53 UTC
+**Date:** 2026-06-19 14:15:05 UTC
 **Status:** 🔴 HIGH TURBULENCE
 
 ### Turbulence Factors:
@@ -34,9 +34,9 @@
 | [1372](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1372) | 🔧 Jules05: Resolve cross-agent conflict in Risk Management and Model interfaces | yxynoty | `Jules05-resolve-cross-agent-conflict-13854965436455603502` | escalated-risk | pending | High Risk | ⚠️ Stale (Pre-Big-Bang) |
 | [1371](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1371) | 🧬 Jules02: Synthetic test scenarios — Risk reconciliation scenarios | xnessom | `jules02/risk-reconciliation-8990552146312303501` | escalated-risk | pending | High Risk | ⚠️ Stale (Pre-Big-Bang) |
 | [1369](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1369) | 🔐 Jules02: Security hardening — HMAC-SHA256 signature verification for model files | xnessom | `jules02-security-hardening-model-signatures-17851897229134920353` | escalated-risk | pending | High Risk | ⚠️ Stale (Pre-Big-Bang) |
-| [1367](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1367) | ⚡ Jules05: Workflow simplification — Comprehensive Log Update | yxynoty | `jules05/workflow-simplification-log-7413812354450014762` | escalated-risk | pending | High Risk | ⚠️ Stale (Pre-Big-Bang) |
-| [1365](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1365) | feat: enhance rare event simulator with stochastic price paths and integration tests | saysgrok | `feat/rare-event-simulator-enhancements-10851597428787068158` | escalated-risk | pending | High Risk | ⚠️ Stale (Pre-Big-Bang) |
-| [1359](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1359) | 💡 Jules02: CLI and operator UX improvement — Centralized loop control and observability | xnessom | `feat/jules-ux-improvements-17355899848812806450` | escalated-risk | pending | Medium Risk | ⚠️ Stale (Pre-Big-Bang) |
+| [1367](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1367) | ⚡ Jules05: Workflow simplification — Comprehensive Log Update | yxynoty | `jules05/workflow-simplification-log-7413812354450014762` | escalated-risk | unknown | Triage Required | ⚠️ Stale (Pre-Big-Bang) |
+| [1365](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1365) | feat: enhance rare event simulator with stochastic price paths and integration tests | saysgrok | `feat/rare-event-simulator-enhancements-10851597428787068158` | escalated-risk | unknown | Triage Required | ⚠️ Stale (Pre-Big-Bang) |
+| [1359](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1359) | 💡 Jules02: CLI and operator UX improvement — Centralized loop control and observability | xnessom | `feat/jules-ux-improvements-17355899848812806450` | escalated-risk | unknown | Medium Risk | ⚠️ Stale (Pre-Big-Bang) |
 | [1358](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1358) | refine institutional decision support system | saysgrok | `jules/decision-support-refinement-14863980251247551831` | none | unknown | Triage Required | ⚠️ Stale (Pre-Big-Bang) |
 | [1355](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1355) | 🤖 Jules05: Auto-merge policy update | yxynoty | `jules-auto-merge-policy-update-v2-16307037561171272572` | escalated-risk | unknown | Triage Required | ⚠️ Stale (Pre-Big-Bang) |
 | [1353](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1353) | Daily PR Intake & Risk Triage Dashboard [2026-05-19] | triqbit | `dx-daily-triage-2026-05-19-3194403183270032630` | none | unknown | High Risk | ⚠️ Stale (Pre-Big-Bang) |


### PR DESCRIPTION
Problem: Jules05 and human reviewers need a focused list of merge candidates to streamline the review process.
Root Cause: High PR volume (556 open PRs) and history-grafting model make manual triage difficult.
Solution: Prepare a daily merge-readiness checklist for 3 promising 'Safe Surface' PRs (#1336, #1300, #1268), documenting their scope, domains touched, and recommending re-validation against the latest graft commit (7089ac2).
Impact: Reduces reviewer cognitive load by pre-processing high-signal candidates.
Validation: Verified docs/status/MERGE_READY_CHECKLIST.md content and hash. Ran tests/test_triage_report.py (3/3 passing).
Safety Check: No changes to core trading or risk logic. Only modified status documentation.
Remaining Gaps: PRs remain stale and require manual rebase/re-validation by authors or reviewers.

---
*PR created automatically by Jules for task [488114446015521987](https://jules.google.com/task/488114446015521987) started by @triqbit*