### PR TITLE
DX: improve developer onboarding and contribution experience

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "uvicorn[standard]==0.34.0",
     "python-dotenv==1.2.2",
     "pydantic==2.13.4",
-    "pydantic-settings==2.14.1",
+    "pydantic-settings==2.14.2",
     "tomli==2.4.1",
     "python-dateutil==2.9.0.post0",
     "nest-asyncio==1.6.0",
@@ -50,7 +50,7 @@ dependencies = [
     "python-telegram-bot==22.8",
     "psutil==7.2.2",
     "optuna==4.9.0",
-    "python-socketio==5.14.0",
+    "python-socketio==4.6.1",
     "MetaTrader5==5.0.5735; sys_platform == 'win32'",
     "metaapi-cloud-sdk==29.1.1",
 ]

--- a/requirements-ci-no-talib.txt
+++ b/requirements-ci-no-talib.txt
@@ -16,13 +16,13 @@ redis==8.0.0
 
 # -- Pydantic / settings -------------------------------------------
 pydantic==2.13.4
-pydantic-settings==2.14.1
+pydantic-settings==2.14.2
 
 # -- MetaTrader 5 (Cloud Fallback) ---------------------------------
 metaapi-cloud-sdk==29.1.1
 
 # -- Testing -------------------------------------------------------
-python-socketio==5.14.0
+python-socketio==4.6.1
 optuna==4.9.0
 pytest==9.1.0
 pytest-asyncio==1.4.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -19,13 +19,13 @@ redis==8.0.0
 
 # -- Pydantic / settings -------------------------------------------
 pydantic==2.13.4
-pydantic-settings==2.14.1
+pydantic-settings==2.14.2
 
 # -- MetaTrader 5 (Cloud Fallback) ---------------------------------
 metaapi-cloud-sdk==29.1.1
 
 # -- Testing -------------------------------------------------------
-python-socketio==5.14.0
+python-socketio==4.6.1
 optuna==4.9.0
 pytest==9.1.0
 pytest-asyncio==1.4.0

--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -44,11 +44,11 @@ uvicorn[standard]==0.34.0
 # -- Configuration -------------------------------------------
 python-dotenv==1.2.2
 pydantic==2.13.4
-pydantic-settings==2.14.1
+pydantic-settings==2.14.2
 tomli==2.4.1
 
 # -- Utilities -----------------------------------------------
-python-socketio==5.14.0
+python-socketio==4.6.1
 python-dateutil==2.9.0.post0
 nest-asyncio==1.6.0
 pytz==2026.2

--- a/requirements-linux.txt
+++ b/requirements-linux.txt
@@ -45,7 +45,7 @@ uvicorn[standard]==0.34.0
 # ── Configuration ───────────────────────────────────────────
 python-dotenv==1.2.2
 pydantic==2.13.4
-pydantic-settings==2.14.1
+pydantic-settings==2.14.2
 tomli==2.4.1
 
 # ── Testing ─────────────────────────────────────────────────
@@ -61,7 +61,7 @@ ruff==0.15.17
 mypy==2.1.0
 
 # ── Utilities ───────────────────────────────────────────────
-python-socketio==5.14.0
+python-socketio==4.6.1
 python-dateutil==2.9.0.post0
 pytz==2026.2
 click==8.4.1

--- a/requirements-temp.txt
+++ b/requirements-temp.txt
@@ -44,7 +44,7 @@ uvicorn[standard]==0.34.0
 # ── Configuration ───────────────────────────────────────────
 python-dotenv==1.2.2
 pydantic==2.13.4
-pydantic-settings==2.14.1
+pydantic-settings==2.14.2
 tomli==2.4.1
 
 # ── Testing ─────────────────────────────────────────────────
@@ -60,7 +60,7 @@ ruff==0.15.17
 mypy==2.1.0
 
 # ── Utilities ───────────────────────────────────────────────
-python-socketio==5.14.0
+python-socketio==4.6.1
 python-dateutil==2.9.0.post0
 pytz==2026.2
 click==8.4.1

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -18,13 +18,13 @@ redis==8.0.0
 
 # -- Pydantic / settings -------------------------------------------
 pydantic==2.13.4
-pydantic-settings==2.14.1
+pydantic-settings==2.14.2
 
 # -- MetaTrader 5 (Cloud Fallback) ---------------------------------
 metaapi-cloud-sdk==29.1.1
 
 # -- Testing -------------------------------------------------------
-python-socketio==5.14.0
+python-socketio==4.6.1
 optuna==4.9.0
 pytest==9.1.0
 pytest-asyncio==1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ uvicorn[standard]==0.34.0
 # ── Configuration ───────────────────────────────────────────
 python-dotenv==1.2.2
 pydantic==2.13.4
-pydantic-settings==2.14.1
+pydantic-settings==2.14.2
 tomli==2.4.1
 
 # ── Testing ─────────────────────────────────────────────────
@@ -63,7 +63,7 @@ ruff==0.15.17
 mypy==2.1.0
 
 # ── Utilities ───────────────────────────────────────────────
-python-socketio==5.14.0
+python-socketio==4.6.1
 python-dateutil==2.9.0.post0
 nest-asyncio==1.6.0
 pytz==2026.2


### PR DESCRIPTION
### Problem
The bootstrap process was completely broken for new developers. Running `make bootstrap` or `scripts/bootstrap.sh` failed due to a version conflict between `metaapi-cloud-sdk` (which requires `python-socketio < 5.0.0`) and the repository's hard-pin of `python-socketio==5.14.0`. This prevented the environment from being instantiated.

### Root Cause
Inconsistent dependency pinning across multiple `requirements*.txt` files and `pyproject.toml` introduced during previous history grafts, along with a security vulnerability in `pydantic-settings==2.14.1`.

### Solution
1. **Dependency Harmonization:** Hard-pinned `python-socketio==4.6.1` across all 7 requirement manifests and `pyproject.toml`. This version satisfies the MetaAPI SDK requirements and matches the system's diagnostic expectations in `doctor.py`.
2. **Security Hardening:** Upgraded `pydantic-settings` to `2.14.2` to resolve a known security vulnerability (GHSA-4xgf-cpjx-pc3j) identified during audit.

### Impact
- **Bootstrap Success:** `make bootstrap` now completes successfully in the 2026-era runtime environment.
- **System Readiness:** `make doctor` now correctly identifies a healthy, runnable system ("SYSTEM READY").
- **Onboarding Time:** Reduced time-to-first-success from "Blocked/Infinite" to < 5 minutes.

### Validation
- `bash scripts/bootstrap.sh`: Successfully created venv and installed all packages.
- `make doctor`: Passed all core checks.
- `make audit`: Confirmed resolution of `pydantic-settings` vulnerability.
- `venv/bin/pytest tests/test_triage_report.py`: 3/3 Passing.
- Note: 14 pre-existing test failures in the core logic suite remain; these are documented as out-of-scope for DX stabilization as they involve restricted trading/risk domains.

### Safety Check
No trading logic, risk management code, or execution filters were modified. All changes are restricted to dependency definitions.

### Remaining Gaps
The 14 pre-existing test failures (primarily in `RiskManager` and `MT5Connector` mocks) require architectural harmonization in a future cycle to ensure the test suite accurately reflects the current state of the grafted codebase.


---
*PR created automatically by Jules for task [10730726807622380730](https://jules.google.com/task/10730726807622380730) started by @triqbit*