### PR TITLE
DX: update daily PR triage and merge-readiness checklist [2026-06-24]

### DIFF
--- a/docs/status/MERGE_READY_CHECKLIST.md
+++ b/docs/status/MERGE_READY_CHECKLIST.md
@@ -1,9 +1,9 @@
 # Merge-Readiness Checklist
 
 > [!IMPORTANT]
-> **Critical Repository State Notice:** The `main` branch is currently operating under a history-grafting model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `c1cb3c3f37743955eb30ff6fa96c51b5ec3352c1` is required for all PRs.**
+> **Critical Repository State Notice:** The `main` branch is currently operating under a history-grafting model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `79dd5a56de7f6e5fd18dfd4257615416e0c0b012` is required for all PRs.**
 
-Generated on: 2026-06-23 13:29:12 UTC
+Generated on: 2026-06-24 13:19:38 UTC
 
 This checklist identifies top promising PRs for immediate review.
 
@@ -11,21 +11,21 @@ This checklist identifies top promising PRs for immediate review.
 - **Short scope summary**: Safe Surface update implementing 'chore(deps): bump gymnasium from 1.0.0 to 1.3.0' (Candidate for re-validation/review)
 - **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `c1cb3c3f37743955eb30ff6fa96c51b5ec3352c1`
+- **Missing items**: Mandatory rebase against commit `79dd5a56de7f6e5fd18dfd4257615416e0c0b012`
 - **Recommendation**: Needs CI success before merge
 
 ## 2. PR #1551: chore(deps): bump tqdm from 4.68.2 to 4.68.3
 - **Short scope summary**: Safe Surface update implementing 'chore(deps): bump tqdm from 4.68.2 to 4.68.3' (Candidate for re-validation/review)
 - **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `c1cb3c3f37743955eb30ff6fa96c51b5ec3352c1`
+- **Missing items**: Mandatory rebase against commit `79dd5a56de7f6e5fd18dfd4257615416e0c0b012`
 - **Recommendation**: Needs CI success before merge
 
 ## 3. PR #1549: chore(deps): bump rich from 13.9.4 to 15.0.0
 - **Short scope summary**: Safe Surface update implementing 'chore(deps): bump rich from 13.9.4 to 15.0.0' (Candidate for re-validation/review)
 - **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `c1cb3c3f37743955eb30ff6fa96c51b5ec3352c1`
+- **Missing items**: Mandatory rebase against commit `79dd5a56de7f6e5fd18dfd4257615416e0c0b012`
 - **Recommendation**: Needs CI success before merge
 
 ---

--- a/docs/status/PR_TRIAGE_DAILY.md
+++ b/docs/status/PR_TRIAGE_DAILY.md
@@ -1,6 +1,6 @@
 # Daily PR Triage Dashboard
 
-**Date:** 2026-06-23 13:29:12 UTC
+**Date:** 2026-06-24 13:19:38 UTC
 **Status:** 🔴 HIGH TURBULENCE
 
 ### Turbulence Factors:
@@ -21,16 +21,16 @@
 | [1552](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1552) | chore(deps): bump gymnasium from 1.0.0 to 1.3.0 | dependabot[bot] | `dependabot/pip/gymnasium-1.3.0` | none | pending | Safe Surface | ⚠️ Stale (Pre-Big-Bang) |
 | [1551](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1551) | chore(deps): bump tqdm from 4.68.2 to 4.68.3 | dependabot[bot] | `dependabot/pip/tqdm-4.68.3` | none | pending | Safe Surface | ⚠️ Stale (Pre-Big-Bang) |
 | [1549](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1549) | chore(deps): bump rich from 13.9.4 to 15.0.0 | dependabot[bot] | `dependabot/pip/rich-15.0.0` | none | pending | Safe Surface | ⚠️ Stale (Pre-Big-Bang) |
-| [1543](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1543) | DX: improve developer onboarding and contribution experience | triqbit | `dx-daily-triage-2026-06-20-qufuwan-7504956792826488201` | none | unknown | Safe Surface | ⚠️ Stale (Pre-Big-Bang) |
-| [1528](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1528) | docs: improve developer onboarding and contribution experience | triqbit | `dx-process-integrity-log-2026-06-16-5084547163796099815` | none | unknown | Safe Surface | ⚠️ Stale (Pre-Big-Bang) |
-| [1525](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1525) | docs: update process integrity log [2026-06-15] | triqbit | `docs/process-integrity-2026-06-15-11231654497632137330` | none | unknown | Safe Surface | ⚠️ Stale (Pre-Big-Bang) |
-| [1510](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1510) | chore(deps): bump torch from 2.5.1+cpu to 2.12.0+cpu | dependabot[bot] | `dependabot/pip/torch-2.12.0cpu` | none | unknown | Safe Surface | ⚠️ Stale (Pre-Big-Bang) |
-| [1470](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1470) | docs: update daily merge-readiness checklist [2026-06-03] | triqbit | `docs-merge-checklist-2026-06-03-12193052405329652474` | none | unknown | Safe Surface | ⚠️ Stale (Pre-Big-Bang) |
-| [1412](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1412) | ✨ Jules05: Product coherence improvements | yxynoty | `jules05-product-coherence-improvements-15654352759067746756` | escalated-risk | unknown | High Risk | ⚠️ Stale (Pre-Big-Bang) |
-| [1409](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1409) | docs: Daily PR triage and risk dashboard [2026-05-23] | triqbit | `dx-daily-merge-checklist-2026-05-23-2325326555346100103` | none | unknown | Safe Surface | ⚠️ Stale (Pre-Big-Bang) |
-| [1404](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1404) | 🔗 Jules05: Integration test results [2026-05-23] | yxynoty | `jules05-integration-results-2026-05-23-1111935695238620886` | escalated-risk | unknown | Triage Required | ⚠️ Stale (Pre-Big-Bang) |
-| [1402](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1402) | ✨ Jules05: Product coherence improvements | yxynoty | `jules05-product-coherence-improvements-5365694077499482405` | escalated-risk | unknown | High Risk | ⚠️ Stale (Pre-Big-Bang) |
-| [1395](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1395) | 🤖 Jules05: Auto-merge policy update | yxynoty | `jules05-auto-merge-policy-update-14778474038957274841` | escalated-risk | unknown | Triage Required | ⚠️ Stale (Pre-Big-Bang) |
+| [1543](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1543) | DX: improve developer onboarding and contribution experience | triqbit | `dx-daily-triage-2026-06-20-qufuwan-7504956792826488201` | none | pending | Safe Surface | ⚠️ Stale (Pre-Big-Bang) |
+| [1528](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1528) | docs: improve developer onboarding and contribution experience | triqbit | `dx-process-integrity-log-2026-06-16-5084547163796099815` | none | pending | Medium Risk | ⚠️ Stale (Pre-Big-Bang) |
+| [1525](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1525) | docs: update process integrity log [2026-06-15] | triqbit | `docs/process-integrity-2026-06-15-11231654497632137330` | none | pending | Medium Risk | ⚠️ Stale (Pre-Big-Bang) |
+| [1510](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1510) | chore(deps): bump torch from 2.5.1+cpu to 2.12.0+cpu | dependabot[bot] | `dependabot/pip/torch-2.12.0cpu` | none | pending | Safe Surface | ⚠️ Stale (Pre-Big-Bang) |
+| [1470](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1470) | docs: update daily merge-readiness checklist [2026-06-03] | triqbit | `docs-merge-checklist-2026-06-03-12193052405329652474` | none | pending | Medium Risk | ⚠️ Stale (Pre-Big-Bang) |
+| [1412](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1412) | ✨ Jules05: Product coherence improvements | yxynoty | `jules05-product-coherence-improvements-15654352759067746756` | escalated-risk | pending | High Risk | ⚠️ Stale (Pre-Big-Bang) |
+| [1409](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1409) | docs: Daily PR triage and risk dashboard [2026-05-23] | triqbit | `dx-daily-merge-checklist-2026-05-23-2325326555346100103` | none | pending | Safe Surface | ⚠️ Stale (Pre-Big-Bang) |
+| [1404](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1404) | 🔗 Jules05: Integration test results [2026-05-23] | yxynoty | `jules05-integration-results-2026-05-23-1111935695238620886` | escalated-risk | pending | High Risk | ⚠️ Stale (Pre-Big-Bang) |
+| [1402](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1402) | ✨ Jules05: Product coherence improvements | yxynoty | `jules05-product-coherence-improvements-5365694077499482405` | escalated-risk | pending | High Risk | ⚠️ Stale (Pre-Big-Bang) |
+| [1395](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1395) | 🤖 Jules05: Auto-merge policy update | yxynoty | `jules05-auto-merge-policy-update-14778474038957274841` | escalated-risk | pending | High Risk | ⚠️ Stale (Pre-Big-Bang) |
 | [1389](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1389) | 📘 Jules02: Documentation and schema governance — Unified decision funnel schemas | xnessom | `jules02/unified-schemas-5643005943939164146` | escalated-risk | pending | High Risk | ⚠️ Stale (Pre-Big-Bang) |
 | [1386](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1386) | 💡 Jules02: CLI and operator UX improvement — Configurable polling and setup wizard enhancements | xnessom | `jules02-cli-ux-improvements-8438108481486765359` | escalated-risk | pending | High Risk | ⚠️ Stale (Pre-Big-Bang) |
 | [1384](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1384) | 🔐 Jules02: Security hardening — HMAC-SHA256 model integrity guard | xnessom | `security/model-integrity-guard-13330429797659203878` | escalated-risk | pending | High Risk | ⚠️ Stale (Pre-Big-Bang) |
@@ -592,7 +592,7 @@
 - **PR #1552**: chore(deps): bump gymnasium from 1.0.0 to 1.3.0 (dependabot[bot]) [CI: pending] - *Safe Surface*
 - **PR #1551**: chore(deps): bump tqdm from 4.68.2 to 4.68.3 (dependabot[bot]) [CI: pending] - *Safe Surface*
 - **PR #1549**: chore(deps): bump rich from 13.9.4 to 15.0.0 (dependabot[bot]) [CI: pending] - *Safe Surface*
-- **PR #1543**: DX: improve developer onboarding and contribution experience (triqbit) - *Safe Surface*
+- **PR #1543**: DX: improve developer onboarding and contribution experience (triqbit) [CI: pending] - *Safe Surface*
 
 ---
 *Note: This report is generated by Jules06 (qufuwan). Risk classification is based on file paths and heuristics.*


### PR DESCRIPTION
This update refreshes the daily PR triage dashboard and merge-readiness checklist for June 24, 2026. 

Key changes:
1. **docs/status/PR_TRIAGE_DAILY.md**: Updated to reflect the current state of 560 open PRs. CI status for several top PRs has transitioned from 'unknown' to 'pending'. Risk classifications have been refined using the latest heuristics.
2. **docs/status/MERGE_READY_CHECKLIST.md**: Updated with the latest 'Safe Surface' candidates (PR #1552, #1551, #1549) and the mandatory rebase commit `79dd5a56de7f6e5fd18dfd4257615416e0c0b012`.

Validation:
- Executed `scripts/generate_triage_report.py` successfully.
- Ran `tests/test_triage_report.py` (3/3 passing).
- Ran `tests/test_triage_heuristics.py` to confirm correct classification of documentation and dependency PRs.
- Verified manual output formatting and link integrity.

---
*PR created automatically by Jules for task [18080623661669822150](https://jules.google.com/task/18080623661669822150) started by @triqbit*