### PR TITLE
docs: update daily merge-readiness checklist [2026-06-26]

### DIFF
--- a/docs/status/MERGE_READY_CHECKLIST.md
+++ b/docs/status/MERGE_READY_CHECKLIST.md
@@ -1,31 +1,31 @@
 # Merge-Readiness Checklist
 
 > [!IMPORTANT]
-> **Critical Repository State Notice:** The `main` branch is currently operating under a history-grafting model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `90f5c5ee017399700bddb3616ad8ce761ce3bcfb` is required for all PRs.**
+> **Critical Repository State Notice:** The `main` branch is currently operating under a history-grafting model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `586abe61283425851c6fdf249976757f08402dda` is required for all PRs.**
 
-Generated on: 2026-06-26 13:21:16 UTC
+Generated on: 2026-06-26 14:18:37 UTC
 
 This checklist identifies top promising PRs for immediate review.
 
-## 1. PR #1552: chore(deps): bump gymnasium from 1.0.0 to 1.3.0
+## 1. PR #1543: DX: improve developer onboarding and contribution experience
+- **Short scope summary**: Safe Surface update improving developer onboarding and contribution experience (Candidate for re-validation/review)
+- **Domains touched**: docs, scripts, makefile
+- **CI status**: pending
+- **Missing items**: Mandatory rebase against commit `586abe61283425851c6fdf249976757f08402dda`
+- **Recommendation**: Ready for detailed review once rebased and CI passes
+
+## 2. PR #1552: chore(deps): bump gymnasium from 1.0.0 to 1.3.0
 - **Short scope summary**: Safe Surface update implementing 'chore(deps): bump gymnasium from 1.0.0 to 1.3.0' (Candidate for re-validation/review)
 - **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `90f5c5ee017399700bddb3616ad8ce761ce3bcfb`
+- **Missing items**: Mandatory rebase against commit `586abe61283425851c6fdf249976757f08402dda`
 - **Recommendation**: Needs CI success before merge
 
-## 2. PR #1551: chore(deps): bump tqdm from 4.68.2 to 4.68.3
+## 3. PR #1551: chore(deps): bump tqdm from 4.68.2 to 4.68.3
 - **Short scope summary**: Safe Surface update implementing 'chore(deps): bump tqdm from 4.68.2 to 4.68.3' (Candidate for re-validation/review)
 - **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `90f5c5ee017399700bddb3616ad8ce761ce3bcfb`
-- **Recommendation**: Needs CI success before merge
-
-## 3. PR #1549: chore(deps): bump rich from 13.9.4 to 15.0.0
-- **Short scope summary**: Safe Surface update implementing 'chore(deps): bump rich from 13.9.4 to 15.0.0' (Candidate for re-validation/review)
-- **Domains touched**: dependencies
-- **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `90f5c5ee017399700bddb3616ad8ce761ce3bcfb`
+- **Missing items**: Mandatory rebase against commit `586abe61283425851c6fdf249976757f08402dda`
 - **Recommendation**: Needs CI success before merge
 
 ---


### PR DESCRIPTION
This update provides the daily merge-readiness checklist for promising 'Safe Surface' PR candidates. It includes scope summaries, domain analysis, and specific rebase requirements against the latest repository state (commit 586abe6) to assist Jules05 and human reviewers in the daily audit.

---
*PR created automatically by Jules for task [17409095838824557544](https://jules.google.com/task/17409095838824557544) started by @triqbit*