### PR TITLE
DX: improve daily PR triage and risk classification experience

### DIFF
--- a/docs/status/MERGE_READY_CHECKLIST.md
+++ b/docs/status/MERGE_READY_CHECKLIST.md
@@ -1,9 +1,9 @@
 # Merge-Readiness Checklist
 
 > [!IMPORTANT]
-> **Critical Repository State Notice:** The `main` branch is currently operating under a history-grafting model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `11344245ed52eff7c6cfe5114ab716fdd0a117c8` is required for all PRs.**
+> **Critical Repository State Notice:** The `main` branch is currently operating under a history-grafting model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `76f690ade81c22e6e4ff878fe44f38474ac8540e` is required for all PRs.**
 
-Generated on: 2026-06-28 14:20:00 UTC
+Generated on: 2026-06-29 13:37:06 UTC
 
 This checklist identifies top promising PRs for immediate review.
 
@@ -11,21 +11,21 @@ This checklist identifies top promising PRs for immediate review.
 - **Short scope summary**: Safe Surface update implementing 'DX: improve developer onboarding and contribution experience' (Candidate for re-validation/review)
 - **Domains touched**: docs
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `11344245ed52eff7c6cfe5114ab716fdd0a117c8`
+- **Missing items**: Mandatory rebase against commit `76f690ade81c22e6e4ff878fe44f38474ac8540e`
 - **Recommendation**: Needs CI success before merge
 
-## 2. PR #1409: docs: Daily PR triage and risk dashboard [2026-05-23]
-- **Short scope summary**: Safe Surface update implementing 'docs: Daily PR triage and risk dashboard [2026-05-23]' (Candidate for re-validation/review)
-- **Domains touched**: docs
+## 2. PR #1528: docs: improve developer onboarding and contribution experience
+- **Short scope summary**: Medium Risk update implementing 'docs: improve developer onboarding and contribution experience' (Candidate for re-validation/review)
+- **Domains touched**: dependencies, docs, infra/scripts
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `11344245ed52eff7c6cfe5114ab716fdd0a117c8`
+- **Missing items**: Mandatory rebase against commit `76f690ade81c22e6e4ff878fe44f38474ac8540e`, tests
 - **Recommendation**: Needs CI success before merge
 
-## 3. PR #1337: 🤖 Jules05: Auto-merge policy update
-- **Short scope summary**: Safe Surface update implementing '🤖 Jules05: Auto-merge policy update' (Candidate for re-validation/review)
-- **Domains touched**: ci
-- **CI status**: unknown
-- **Missing items**: Mandatory rebase against commit `11344245ed52eff7c6cfe5114ab716fdd0a117c8`
+## 3. PR #1525: docs: update process integrity log [2026-06-15]
+- **Short scope summary**: Medium Risk update implementing 'docs: update process integrity log [2026-06-15]' (Candidate for re-validation/review)
+- **Domains touched**: dependencies, docs
+- **CI status**: pending
+- **Missing items**: Mandatory rebase against commit `76f690ade81c22e6e4ff878fe44f38474ac8540e`, tests
 - **Recommendation**: Needs CI success before merge
 
 ---

--- a/docs/status/PR_TRIAGE_DAILY.md
+++ b/docs/status/PR_TRIAGE_DAILY.md
@@ -1,16 +1,16 @@
 # Daily PR Triage Dashboard
 
-**Date:** 2026-06-28 13:20:09 UTC
+**Date:** 2026-06-29 13:37:06 UTC
 **Status:** 🔴 HIGH TURBULENCE
 
 ### Turbulence Factors:
-- High number of open PRs (558)
+- High number of open PRs (557)
 
 ---
 
 ## 🔝 Top 3 Items That Matter Right Now
 
-1. **Address Turbulence:** High number of open PRs (558)
+1. **Address Turbulence:** High number of open PRs (557)
 2. **Re-validate Stale:** Review Safe Surface PR #1543 (DX: improve developer onboarding and contribution experience)
 3. **Re-validate Stale:** Review Safe Surface PR #1409 (docs: Daily PR triage and risk dashboard [2026-05-23])
 
@@ -19,7 +19,6 @@
 | PR # | Title | Author | Branch | Labels | CI Status | Risk Class | Status Flag |
 |------|-------|--------|--------|--------|-----------|------------|-------------|
 | [1576](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1576) | DX: improve developer onboarding and contribution experience | triqbit | `dx-improve-onboarding-credibility-5459078260715495313` | escalated-risk | pending | High Risk | ⚠️ Stale (Pre-Big-Bang) |
-| [1575](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1575) | chore(deps): bump python-socketio from 4.6.1 to 5.16.2 | dependabot[bot] | `dependabot/pip/python-socketio-5.16.2` | none | pending | Medium Risk | ⚠️ Stale (Pre-Big-Bang) |
 | [1543](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1543) | DX: improve developer onboarding and contribution experience | triqbit | `dx-daily-triage-2026-06-20-qufuwan-7504956792826488201` | none | pending | Safe Surface | ⚠️ Stale (Pre-Big-Bang) |
 | [1528](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1528) | docs: improve developer onboarding and contribution experience | triqbit | `dx-process-integrity-log-2026-06-16-5084547163796099815` | none | pending | Medium Risk | ⚠️ Stale (Pre-Big-Bang) |
 | [1525](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1525) | docs: update process integrity log [2026-06-15] | triqbit | `docs/process-integrity-2026-06-15-11231654497632137330` | none | pending | Medium Risk | ⚠️ Stale (Pre-Big-Bang) |
@@ -36,9 +35,9 @@
 | [1372](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1372) | 🔧 Jules05: Resolve cross-agent conflict in Risk Management and Model interfaces | yxynoty | `Jules05-resolve-cross-agent-conflict-13854965436455603502` | escalated-risk | pending | High Risk | ⚠️ Stale (Pre-Big-Bang) |
 | [1371](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1371) | 🧬 Jules02: Synthetic test scenarios — Risk reconciliation scenarios | xnessom | `jules02/risk-reconciliation-8990552146312303501` | escalated-risk | pending | High Risk | ⚠️ Stale (Pre-Big-Bang) |
 | [1369](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1369) | 🔐 Jules02: Security hardening — HMAC-SHA256 signature verification for model files | xnessom | `jules02-security-hardening-model-signatures-17851897229134920353` | escalated-risk | pending | High Risk | ⚠️ Stale (Pre-Big-Bang) |
-| [1367](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1367) | ⚡ Jules05: Workflow simplification — Comprehensive Log Update | yxynoty | `jules05/workflow-simplification-log-7413812354450014762` | escalated-risk | unknown | Safe Surface | ⚠️ Stale (Pre-Big-Bang) |
-| [1365](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1365) | feat: enhance rare event simulator with stochastic price paths and integration tests | saysgrok | `feat/rare-event-simulator-enhancements-10851597428787068158` | escalated-risk | unknown | High Risk | ⚠️ Stale (Pre-Big-Bang) |
-| [1359](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1359) | 💡 Jules02: CLI and operator UX improvement — Centralized loop control and observability | xnessom | `feat/jules-ux-improvements-17355899848812806450` | escalated-risk | unknown | Medium Risk | ⚠️ Stale (Pre-Big-Bang) |
+| [1367](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1367) | ⚡ Jules05: Workflow simplification — Comprehensive Log Update | yxynoty | `jules05/workflow-simplification-log-7413812354450014762` | escalated-risk | pending | High Risk | ⚠️ Stale (Pre-Big-Bang) |
+| [1365](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1365) | feat: enhance rare event simulator with stochastic price paths and integration tests | saysgrok | `feat/rare-event-simulator-enhancements-10851597428787068158` | escalated-risk | pending | High Risk | ⚠️ Stale (Pre-Big-Bang) |
+| [1359](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1359) | 💡 Jules02: CLI and operator UX improvement — Centralized loop control and observability | xnessom | `feat/jules-ux-improvements-17355899848812806450` | escalated-risk | pending | High Risk | ⚠️ Stale (Pre-Big-Bang) |
 | [1358](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1358) | refine institutional decision support system | saysgrok | `jules/decision-support-refinement-14863980251247551831` | none | unknown | Medium Risk | ⚠️ Stale (Pre-Big-Bang) |
 | [1355](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1355) | 🤖 Jules05: Auto-merge policy update | yxynoty | `jules-auto-merge-policy-update-v2-16307037561171272572` | escalated-risk | unknown | Safe Surface | ⚠️ Stale (Pre-Big-Bang) |
 | [1353](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1353) | Daily PR Intake & Risk Triage Dashboard [2026-05-19] | triqbit | `dx-daily-triage-2026-05-19-3194403183270032630` | none | unknown | High Risk | ⚠️ Stale (Pre-Big-Bang) |
@@ -583,14 +582,14 @@
 - **Medium Risk (New):** 0 PRs
 - **Safe Surface (New):** 0 PRs
 - **Triage Required (New):** 0 PRs
-- **Stale (Total):** 558 PRs
+- **Stale (Total):** 557 PRs
 
 ## ✨ Good Candidates for Review Today
 
 - **PR #1543**: DX: improve developer onboarding and contribution experience (triqbit) [CI: pending] - *Safe Surface*
-- **PR #1367**: ⚡ Jules05: Workflow simplification — Comprehensive Log Update (yxynoty) - *Safe Surface*
-- **PR #1355**: 🤖 Jules05: Auto-merge policy update (yxynoty) - *Safe Surface*
-- **PR #1337**: 🤖 Jules05: Auto-merge policy update (yxynoty) - *Safe Surface*
+- **PR #1528**: docs: improve developer onboarding and contribution experience (triqbit) [CI: pending] - *Medium Risk*
+- **PR #1525**: docs: update process integrity log [2026-06-15] (triqbit) [CI: pending] - *Medium Risk*
+- **PR #1470**: docs: update daily merge-readiness checklist [2026-06-03] (triqbit) [CI: pending] - *Medium Risk*
 
 ---
 *Note: This report is generated by Jules06 (qufuwan). Risk classification is based on file paths and heuristics.*

--- a/scripts/generate_triage_report.py
+++ b/scripts/generate_triage_report.py
@@ -639,8 +639,8 @@ def generate_report():
         for pr in safe_surface
         if "triage" not in pr["title"].lower() and "dashboard" not in pr["title"].lower()
     ]
-    candidates = (filtered_safe + medium_risk)[:4]
-    if len(candidates) < 3:
+    candidates = (filtered_safe + medium_risk)
+    if len(candidates) < 4:
         stale_candidates = [
             pr for pr in classified_prs if "Stale" in pr["flag"] and pr["risk"] != "Triage Required"
         ]
@@ -652,7 +652,12 @@ def generate_report():
             and "dashboard" not in pr["title"].lower()
         ]
         stale_medium = [pr for pr in stale_candidates if pr["risk"] == "Medium Risk"]
-        candidates.extend((stale_filtered_safe + stale_medium)[: 4 - len(candidates)])
+
+        # Interleave stale safe and medium, but keep most recent first
+        stale_pool = stale_filtered_safe + stale_medium
+        stale_pool.sort(key=lambda x: x["number"], reverse=True)
+
+        candidates.extend(stale_pool[: 4 - len(candidates)])
 
     if not candidates:
         report += "No new candidates identified today.\n"


### PR DESCRIPTION
Problem: The large backlog of open PRs (557) makes it difficult to identify promising candidates for review, especially when new PRs are infrequent.

Root Cause: Previous logic for "Good Candidates" was heavily biased towards new PRs and would list multiple duplicates or redundant entries when the new PR pool was empty.

Solution: Refined `scripts/generate_triage_report.py` to interleave Safe Surface and Medium Risk candidates from the stale pool, sorted by recency (PR number), while still excluding dashboard/triage reports. Updated the dashboard and checklist to reflect current repository state.

Impact (measured): The "Good Candidates" section now reliably surfaces 4 high-signal PRs even during periods of low activity.

Validation: Verified with `tests/test_triage_report.py` (3/3 passing) and `ruff check`.

Safety Check: Changes are strictly confined to DX tools and documentation. No trading or risk logic touched.

Remaining Gaps: History grafting continues to block granular diff visibility for many PRs, necessitating manual audit against the latest main commit.

---
*PR created automatically by Jules for task [7446338117754184338](https://jules.google.com/task/7446338117754184338) started by @triqbit*