### PR TITLE
docs: update daily merge-readiness checklist [2026-07-16]

### DIFF
--- a/docs/status/MERGE_READY_CHECKLIST.md
+++ b/docs/status/MERGE_READY_CHECKLIST.md
@@ -3,30 +3,33 @@
 > [!IMPORTANT]
 > **Critical Repository State Notice:** The `main` branch is currently operating under a history-grafting model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `3d0a0bcf020da0f803dd1662c4d5499f5358b35e` is required for all PRs.**
 
-Generated on: 2026-07-16 13:05:56 UTC
+Generated on: 2026-07-16 14:25:00 UTC
 
-This checklist identifies top promising PRs for immediate review.
+This checklist identifies top promising PRs for immediate review. Note that CI is currently in a `pending` state for many PRs due to persistent baseline lint errors in the repository (the "Global Blockade").
 
 ## 1. PR #1661: DX: update process integrity log and project health [2026-07-14]
-- **Short scope summary**: Safe Surface update implementing 'DX: update process integrity log and project health [2026-07-14]' (Candidate for re-validation/review)
+- **Short scope summary**: Safe Surface documentation update for process integrity and project health metrics.
 - **Domains touched**: docs
-- **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `3d0a0bcf020da0f803dd1662c4d5499f5358b35e`
-- **Recommendation**: Needs CI success before merge
+- **CI status**: pending (Blocked by repository-wide lint baseline)
+- **Key Checks**: Lint (pending), Test (pending), Audit (pending)
+- **Missing items**: Mandatory rebase against commit `3d0a0bcf020da0f803dd1662c4d5499f5358b35e`.
+- **Recommendation**: Ready for review once rebased; logic-safe documentation only.
 
 ## 2. PR #1653: chore(deps): bump uvicorn from 0.50.0 to 0.51.0
-- **Short scope summary**: Medium Risk update implementing 'chore(deps): bump uvicorn from 0.50.0 to 0.51.0' (Candidate for re-validation/review)
+- **Short scope summary**: Dependency update for uvicorn server (0.50.0 to 0.51.0).
 - **Domains touched**: dependencies
-- **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `3d0a0bcf020da0f803dd1662c4d5499f5358b35e`, tests, docs
-- **Recommendation**: Needs CI success before merge
+- **CI status**: pending (Blocked by repository-wide lint baseline)
+- **Key Checks**: Lint (pending), Test (pending), Audit (pending)
+- **Missing items**: Mandatory rebase against commit `3d0a0bcf020da0f803dd1662c4d5499f5358b35e`, tests, docs.
+- **Recommendation**: Candidate for review; requires validation of dependency compatibility and CI success.
 
 ## 3. PR #1649: chore(deps): bump gymnasium from 1.0.0 to 1.3.0
-- **Short scope summary**: Safe Surface update implementing 'chore(deps): bump gymnasium from 1.0.0 to 1.3.0' (Candidate for re-validation/review)
+- **Short scope summary**: Safe Surface dependency update for gymnasium (1.0.0 to 1.3.0).
 - **Domains touched**: dependencies
-- **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `3d0a0bcf020da0f803dd1662c4d5499f5358b35e`
-- **Recommendation**: Needs CI success before merge
+- **CI status**: pending (Blocked by repository-wide lint baseline)
+- **Key Checks**: Lint (pending), Test (pending), Audit (pending)
+- **Missing items**: Mandatory rebase against commit `3d0a0bcf020da0f803dd1662c4d5499f5358b35e`.
+- **Recommendation**: Ready for review after rebase; low risk surface.
 
 ---
 *Prepared by Jules06 (qufuwan) for Jules05 and human review.*


### PR DESCRIPTION
This daily update prepares the merge-readiness checklist for July 16, 2026. 

Selected PRs:
- #1661 (DX: process integrity and project health)
- #1653 (uvicorn bump)
- #1649 (gymnasium bump)

All selected PRs are categorized as 'Safe Surface' or 'Medium Risk'. The checklist explicitly notes the requirement for a mandatory rebase against commit `3d0a0bcf020da0f803dd1662c4d5499f5358b35e` and acknowledges that the 'pending' CI status is due to the persistent repository-wide lint blockade.

Verified via `pytest tests/test_triage_report.py`.

---
*PR created automatically by Jules for task [3465637602908127189](https://jules.google.com/task/3465637602908127189) started by @triqbit*