### PR TITLE
DX: improve developer onboarding and contribution experience

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "python-telegram-bot==22.8",
     "psutil==7.2.2",
     "optuna==4.9.0",
-    "python-socketio==5.16.2",
+    "python-socketio==4.6.1",
     "MetaTrader5==5.0.5735; sys_platform == 'win32'",
     "metaapi-cloud-sdk==29.1.1",
 ]

--- a/requirements-ci-no-talib.txt
+++ b/requirements-ci-no-talib.txt
@@ -22,7 +22,7 @@ pydantic-settings==2.14.2
 metaapi-cloud-sdk==29.1.1
 
 # -- Testing -------------------------------------------------------
-python-socketio==5.16.2
+python-socketio==4.6.1
 optuna==4.9.0
 pytest==9.1.1
 pytest-asyncio==1.4.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -25,7 +25,7 @@ pydantic-settings==2.14.2
 metaapi-cloud-sdk==29.1.1
 
 # -- Testing -------------------------------------------------------
-python-socketio==5.16.2
+python-socketio==4.6.1
 optuna==4.9.0
 pytest==9.1.1
 pytest-asyncio==1.4.0

--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -48,7 +48,7 @@ pydantic-settings==2.14.2
 tomli==2.4.1
 
 # -- Utilities -----------------------------------------------
-python-socketio==5.16.2
+python-socketio==4.6.1
 python-dateutil==2.9.0.post0
 nest-asyncio==1.6.0
 pytz==2026.2

--- a/requirements-linux.txt
+++ b/requirements-linux.txt
@@ -61,7 +61,7 @@ ruff==0.15.21
 mypy==2.2.0
 
 # ── Utilities ───────────────────────────────────────────────
-python-socketio==5.16.2
+python-socketio==4.6.1
 python-dateutil==2.9.0.post0
 pytz==2026.2
 click==8.4.2

--- a/requirements-temp.txt
+++ b/requirements-temp.txt
@@ -60,7 +60,7 @@ ruff==0.15.21
 mypy==2.2.0
 
 # ── Utilities ───────────────────────────────────────────────
-python-socketio==5.16.2
+python-socketio==4.6.1
 python-dateutil==2.9.0.post0
 pytz==2026.2
 click==8.4.2

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -24,7 +24,7 @@ pydantic-settings==2.14.2
 metaapi-cloud-sdk==29.1.1
 
 # -- Testing -------------------------------------------------------
-python-socketio==5.16.2
+python-socketio==4.6.1
 optuna==4.9.0
 pytest==9.1.1
 pytest-asyncio==1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,7 +63,7 @@ ruff==0.15.21
 mypy==2.2.0
 
 # ── Utilities ───────────────────────────────────────────────
-python-socketio==5.16.2
+python-socketio==4.6.1
 python-dateutil==2.9.0.post0
 nest-asyncio==1.6.0
 pytz==2026.2


### PR DESCRIPTION
1. Problem:
- Dependency conflict: python-socketio was bumped to 5.16.2 which is incompatible with metaapi-cloud-sdk (requires <5.0.0, >=4.6.0). This completely blocks virtual environment installation via 'make bootstrap'.

2. Root Cause:
- Dependabot auto-bumped python-socketio to 5.16.2 without verifying integration compatibility with older SDK packages.

3. Solution:
- Pin python-socketio back to 4.6.1 in pyproject.toml and all 7 requirements files.

4. Impact:
- Developers can bootstrap and run environment diagnostics instantly. 'make bootstrap' and 'make doctor' now succeed with a clean 'SYSTEM READY' status.

5. Validation:
- Ran 'make bootstrap', 'make doctor', and 'make test' with clean results and verified all diagnostics pass.

6. Safety Check:
- Verified no restricted domains (trading, risk, or execution logic) were altered.

7. Remaining Gaps:
- None for this PR.

---
*PR created automatically by Jules for task [4474859630054935900](https://jules.google.com/task/4474859630054935900) started by @triqbit*