### PR TITLE
docs: update daily PR triage and merge-readiness checklist [2026-07-19]

### DIFF
--- a/docs/status/MERGE_READY_CHECKLIST.md
+++ b/docs/status/MERGE_READY_CHECKLIST.md
@@ -1,9 +1,9 @@
 # Merge-Readiness Checklist
 
 > [!IMPORTANT]
-> **Critical Repository State Notice:** The `main` branch is currently operating under a history-grafting model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `86739c031fa64b2e4d66f8e0834c19169e2008cd` is required for all PRs.**
+> **Critical Repository State Notice:** The `main` branch is currently operating under a history-grafting model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `05b7d6a64bc9e2995f0161228ff795ba51e40ec2` is required for all PRs.**
 
-Generated on: 2026-07-18 14:20:42 UTC
+Generated on: 2026-07-19 13:15:56 UTC
 
 This checklist identifies top promising PRs for immediate review.
 
@@ -11,21 +11,21 @@ This checklist identifies top promising PRs for immediate review.
 - **Short scope summary**: Safe Surface update implementing 'chore(deps): bump torch from 2.12.0+cpu to 2.12.1+cpu' (Candidate for re-validation/review)
 - **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `86739c031fa64b2e4d66f8e0834c19169e2008cd`
+- **Missing items**: Mandatory rebase against commit `05b7d6a64bc9e2995f0161228ff795ba51e40ec2`
 - **Recommendation**: Needs CI success before merge
 
 ## 2. PR #1661: DX: update process integrity log and project health [2026-07-14]
 - **Short scope summary**: Safe Surface update implementing 'DX: update process integrity log and project health [2026-07-14]' (Candidate for re-validation/review)
 - **Domains touched**: docs
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `86739c031fa64b2e4d66f8e0834c19169e2008cd`
+- **Missing items**: Mandatory rebase against commit `05b7d6a64bc9e2995f0161228ff795ba51e40ec2`
 - **Recommendation**: Needs CI success before merge
 
 ## 3. PR #1653: chore(deps): bump uvicorn from 0.50.0 to 0.51.0
 - **Short scope summary**: Medium Risk update implementing 'chore(deps): bump uvicorn from 0.50.0 to 0.51.0' (Candidate for re-validation/review)
 - **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `86739c031fa64b2e4d66f8e0834c19169e2008cd`, tests, docs
+- **Missing items**: Mandatory rebase against commit `05b7d6a64bc9e2995f0161228ff795ba51e40ec2`, tests, docs
 - **Recommendation**: Needs CI success before merge
 
 ---

--- a/docs/status/PR_TRIAGE_DAILY.md
+++ b/docs/status/PR_TRIAGE_DAILY.md
@@ -1,6 +1,6 @@
 # Daily PR Triage Dashboard
 
-**Date:** 2026-07-18 14:20:42 UTC
+**Date:** 2026-07-19 13:15:56 UTC
 **Status:** 🔴 HIGH TURBULENCE
 
 ### Turbulence Factors:
@@ -10,7 +10,7 @@
 
 ## 🔝 Top 3 Items That Matter Right Now
 
-1. **Mandatory Rebase:** All open PRs require a mandatory rebase against commit `86739c031fa64b2e4d66f8e0834c19169e2008cd` to ensure compatibility.
+1. **Mandatory Rebase:** All open PRs require a mandatory rebase against commit `05b7d6a64bc9e2995f0161228ff795ba51e40ec2` to ensure compatibility.
 2. **Address Turbulence:** High number of open PRs (561)
 3. **Re-validate Stale:** Review Safe Surface PR #1672 (chore(deps): bump torch from 2.12.0+cpu to 2.12.1+cpu)
 


### PR DESCRIPTION
Generated and updated the daily PR triage report and merge readiness checklist to provide a current status of open PRs, their CI status, risk classifications, and updated mandatory rebase targets.

---
*PR created automatically by Jules for task [12021193064944046697](https://jules.google.com/task/12021193064944046697) started by @triqbit*