### PR TITLE
docs: update daily merge-readiness checklist [2026-07-22]

### DIFF
--- a/docs/status/MERGE_READY_CHECKLIST.md
+++ b/docs/status/MERGE_READY_CHECKLIST.md
@@ -1,9 +1,9 @@
 # Merge-Readiness Checklist
 
 > [!IMPORTANT]
-> **Critical Repository State Notice:** The `main` branch is currently operating under a history-grafting model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `cc7d14282a9e3204960fe0d0066f3fd79be0e77d` is required for all PRs.**
+> **Critical Repository State Notice:** The `main` branch is currently operating under a history-grafting model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `6dee6f8a504822617dd9ae12a0dcc74146c953b1` is required for all PRs.**
 
-Generated on: 2026-07-22 13:10:24 UTC
+Generated on: 2026-07-22 18:00:00 UTC
 
 This checklist identifies top promising PRs for immediate review.
 
@@ -11,21 +11,21 @@ This checklist identifies top promising PRs for immediate review.
 - **Short scope summary**: Safe Surface update implementing 'docs: update process integrity log [2026-07-21]' (Candidate for re-validation/review)
 - **Domains touched**: docs
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `cc7d14282a9e3204960fe0d0066f3fd79be0e77d`
+- **Missing items**: Mandatory rebase against commit `6dee6f8a504822617dd9ae12a0dcc74146c953b1`
 - **Recommendation**: Needs CI success before merge
 
 ## 2. PR #1661: DX: update process integrity log and project health [2026-07-14]
 - **Short scope summary**: Safe Surface update implementing 'DX: update process integrity log and project health [2026-07-14]' (Candidate for re-validation/review)
 - **Domains touched**: docs
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `cc7d14282a9e3204960fe0d0066f3fd79be0e77d`
+- **Missing items**: Mandatory rebase against commit `6dee6f8a504822617dd9ae12a0dcc74146c953b1`
 - **Recommendation**: Needs CI success before merge
 
 ## 3. PR #1653: chore(deps): bump uvicorn from 0.50.0 to 0.51.0
 - **Short scope summary**: Medium Risk update implementing 'chore(deps): bump uvicorn from 0.50.0 to 0.51.0' (Candidate for re-validation/review)
 - **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `cc7d14282a9e3204960fe0d0066f3fd79be0e77d`, tests, docs
+- **Missing items**: Mandatory rebase against commit `6dee6f8a504822617dd9ae12a0dcc74146c953b1`, tests, docs
 - **Recommendation**: Needs CI success before merge
 
 ---


### PR DESCRIPTION
Updated the daily merge-readiness checklist under docs/status/MERGE_READY_CHECKLIST.md for July 22, 2026. Identified top promising review candidates (PR #1697, PR #1661, PR #1653) with detail checklists and established commit 6dee6f8a504822617dd9ae12a0dcc74146c953b1 as the mandatory rebase target.

---
*PR created automatically by Jules for task [13322068364592483487](https://jules.google.com/task/13322068364592483487) started by @triqbit*