### PR TITLE
docs: update daily PR triage and merge-readiness checklist [2026-07-24]

### DIFF
--- a/docs/status/MERGE_READY_CHECKLIST.md
+++ b/docs/status/MERGE_READY_CHECKLIST.md
@@ -1,9 +1,9 @@
 # Merge-Readiness Checklist
 
 > [!IMPORTANT]
-> **Critical Repository State Notice:** The `main` branch is currently operating under a history-grafting model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `e308f62d8260a2ec54f4023d44338c63ff457372` is required for all PRs.**
+> **Critical Repository State Notice:** The `main` branch is currently operating under a history-grafting model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `2d86e6b3b5210538325689ffa92dd572556fdfd7` is required for all PRs.**
 
-Generated on: 2026-07-24 13:29:29 UTC
+Generated on: 2026-07-24 14:29:36 UTC
 
 This checklist identifies top promising PRs for immediate review.
 
@@ -11,21 +11,21 @@ This checklist identifies top promising PRs for immediate review.
 - **Short scope summary**: Safe Surface update implementing 'docs: update process integrity log [2026-07-21]' (Candidate for re-validation/review)
 - **Domains touched**: docs
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `e308f62d8260a2ec54f4023d44338c63ff457372`
+- **Missing items**: Mandatory rebase against commit `2d86e6b3b5210538325689ffa92dd572556fdfd7`
 - **Recommendation**: Needs CI success before merge
 
 ## 2. PR #1661: DX: update process integrity log and project health [2026-07-14]
 - **Short scope summary**: Safe Surface update implementing 'DX: update process integrity log and project health [2026-07-14]' (Candidate for re-validation/review)
 - **Domains touched**: docs
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `e308f62d8260a2ec54f4023d44338c63ff457372`
+- **Missing items**: Mandatory rebase against commit `2d86e6b3b5210538325689ffa92dd572556fdfd7`
 - **Recommendation**: Needs CI success before merge
 
 ## 3. PR #1653: chore(deps): bump uvicorn from 0.50.0 to 0.51.0
 - **Short scope summary**: Medium Risk update implementing 'chore(deps): bump uvicorn from 0.50.0 to 0.51.0' (Candidate for re-validation/review)
 - **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `e308f62d8260a2ec54f4023d44338c63ff457372`, tests, docs
+- **Missing items**: Mandatory rebase against commit `2d86e6b3b5210538325689ffa92dd572556fdfd7`, tests, docs
 - **Recommendation**: Needs CI success before merge
 
 ---

--- a/docs/status/PR_TRIAGE_DAILY.md
+++ b/docs/status/PR_TRIAGE_DAILY.md
@@ -1,6 +1,6 @@
 # Daily PR Triage Dashboard
 
-**Date:** 2026-07-24 13:29:29 UTC
+**Date:** 2026-07-24 14:29:36 UTC
 **Status:** 🔴 HIGH TURBULENCE
 
 ### Turbulence Factors:
@@ -10,7 +10,7 @@
 
 ## 🔝 Top 3 Items That Matter Right Now
 
-1. **Mandatory Rebase:** All open PRs require a mandatory rebase against commit `e308f62d8260a2ec54f4023d44338c63ff457372` to ensure compatibility.
+1. **Mandatory Rebase:** All open PRs require a mandatory rebase against commit `2d86e6b3b5210538325689ffa92dd572556fdfd7` to ensure compatibility.
 2. **Address Turbulence:** High number of open PRs (562)
 3. **Re-validate Stale:** Review Safe Surface PR #1697 (docs: update process integrity log [2026-07-21])
 


### PR DESCRIPTION
Daily generation and update of the PR triage dashboard and merge-readiness checklist for July 24, 2026, synchronizing with the active main branch graft (2d86e6b3b5210538325689ffa92dd572556fdfd7).

---
*PR created automatically by Jules for task [16169093457591566574](https://jules.google.com/task/16169093457591566574) started by @triqbit*