### PR TITLE
docs: update daily PR triage dashboard and merge-readiness checklist [2026-07-25]

### DIFF
--- a/docs/status/MERGE_READY_CHECKLIST.md
+++ b/docs/status/MERGE_READY_CHECKLIST.md
@@ -1,9 +1,9 @@
 # Merge-Readiness Checklist
 
 > [!IMPORTANT]
-> **Critical Repository State Notice:** The `main` branch is currently operating under a history-grafting model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `eee73fe37281c21feb7ccfcbfa4216964391ad5c` is required for all PRs.**
+> **Critical Repository State Notice:** The `main` branch is currently operating under a history-grafting model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `e756672a6ba3160b9d6fe7fd984a455f5e5f6ca3` is required for all PRs.**
 
-Generated on: 2026-07-25 11:23:22 UTC
+Generated on: 2026-07-25 14:38:06 UTC
 
 This checklist identifies top promising PRs for immediate review.
 
@@ -11,21 +11,21 @@ This checklist identifies top promising PRs for immediate review.
 - **Short scope summary**: Safe Surface update implementing 'docs: update process integrity log [2026-07-21]' (Candidate for re-validation/review)
 - **Domains touched**: docs
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `eee73fe37281c21feb7ccfcbfa4216964391ad5c`
+- **Missing items**: Mandatory rebase against commit `e756672a6ba3160b9d6fe7fd984a455f5e5f6ca3`
 - **Recommendation**: Needs CI success before merge
 
 ## 2. PR #1661: DX: update process integrity log and project health [2026-07-14]
 - **Short scope summary**: Safe Surface update implementing 'DX: update process integrity log and project health [2026-07-14]' (Candidate for re-validation/review)
 - **Domains touched**: docs
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `eee73fe37281c21feb7ccfcbfa4216964391ad5c`
+- **Missing items**: Mandatory rebase against commit `e756672a6ba3160b9d6fe7fd984a455f5e5f6ca3`
 - **Recommendation**: Needs CI success before merge
 
 ## 3. PR #1653: chore(deps): bump uvicorn from 0.50.0 to 0.51.0
 - **Short scope summary**: Medium Risk update implementing 'chore(deps): bump uvicorn from 0.50.0 to 0.51.0' (Candidate for re-validation/review)
 - **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `eee73fe37281c21feb7ccfcbfa4216964391ad5c`, tests, docs
+- **Missing items**: Mandatory rebase against commit `e756672a6ba3160b9d6fe7fd984a455f5e5f6ca3`, tests, docs
 - **Recommendation**: Needs CI success before merge
 
 ---

--- a/docs/status/PR_TRIAGE_DAILY.md
+++ b/docs/status/PR_TRIAGE_DAILY.md
@@ -1,6 +1,6 @@
 # Daily PR Triage Dashboard
 
-**Date:** 2026-07-25 11:23:22 UTC
+**Date:** 2026-07-25 14:38:06 UTC
 **Status:** 🔴 HIGH TURBULENCE
 
 ### Turbulence Factors:
@@ -10,7 +10,7 @@
 
 ## 🔝 Top 3 Items That Matter Right Now
 
-1. **Mandatory Rebase:** All open PRs require a mandatory rebase against commit `eee73fe37281c21feb7ccfcbfa4216964391ad5c` to ensure compatibility.
+1. **Mandatory Rebase:** All open PRs require a mandatory rebase against commit `e756672a6ba3160b9d6fe7fd984a455f5e5f6ca3` to ensure compatibility.
 2. **Address Turbulence:** High number of open PRs (562)
 3. **Re-validate Stale:** Review Safe Surface PR #1697 (docs: update process integrity log [2026-07-21])
 


### PR DESCRIPTION
Updated the daily PR triage dashboard and merge-readiness checklists under docs/status/ to reflect the latest commit on main as of Sat Jul 25, 2026, selecting three low/medium-risk candidates for easy review.

---
*PR created automatically by Jules for task [12711066729014074719](https://jules.google.com/task/12711066729014074719) started by @triqbit*