### PR TITLE
Add optional TickerAll hosted MT5 API path to MT5Connector

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dependencies = [
     "python-socketio==4.6.1",
     "MetaTrader5==5.0.5735; sys_platform == 'win32'",
     "metaapi-cloud-sdk==29.1.1",
+    "tickerall>=0.1.16",
 ]
 
 [project.optional-dependencies]

--- a/requirements-ci-no-talib.txt
+++ b/requirements-ci-no-talib.txt
@@ -20,6 +20,7 @@ pydantic-settings==2.14.2
 
 # -- MetaTrader 5 (Cloud Fallback) ---------------------------------
 metaapi-cloud-sdk==29.1.1
+tickerall>=0.1.16
 
 # -- Testing -------------------------------------------------------
 python-socketio==4.6.1

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -23,6 +23,7 @@ pydantic-settings==2.14.2
 
 # -- MetaTrader 5 (Cloud Fallback) ---------------------------------
 metaapi-cloud-sdk==29.1.1
+tickerall>=0.1.16
 
 # -- Testing -------------------------------------------------------
 python-socketio==4.6.1

--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -23,6 +23,7 @@ httpx==0.28.1
 
 # -- MetaTrader 5 (Cloud Fallback) ---------------------------
 metaapi-cloud-sdk==29.1.1
+tickerall>=0.1.16
 
 # -- Database ------------------------------------------------
 psycopg2-binary==2.9.12

--- a/requirements-linux.txt
+++ b/requirements-linux.txt
@@ -25,6 +25,7 @@ httpx==0.28.1
 
 # ── MetaTrader 5 (Cloud Fallback) ───────────────────────────
 metaapi-cloud-sdk==29.1.1
+tickerall>=0.1.16
 
 # ── Database ────────────────────────────────────────────────
 psycopg2-binary==2.9.12

--- a/requirements-temp.txt
+++ b/requirements-temp.txt
@@ -24,6 +24,7 @@ httpx==0.28.1
 
 # ── MetaTrader 5 (Cloud Fallback) ───────────────────────────
 metaapi-cloud-sdk==29.1.1
+tickerall>=0.1.16
 
 # ── Database ────────────────────────────────────────────────
 psycopg2-binary==2.9.12

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -22,6 +22,7 @@ pydantic-settings==2.14.2
 
 # -- MetaTrader 5 (Cloud Fallback) ---------------------------------
 metaapi-cloud-sdk==29.1.1
+tickerall>=0.1.16
 
 # -- Testing -------------------------------------------------------
 python-socketio==4.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ httpx==0.28.1
 # ── MetaTrader 5 ────────────────────────────────────────────
 MetaTrader5==5.0.5735; sys_platform == 'win32'
 metaapi-cloud-sdk==29.1.1
+tickerall>=0.1.16
 
 # ── Database ────────────────────────────────────────────────
 psycopg2-binary==2.9.12

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -54,6 +54,19 @@ class TradingConfig(BaseSettings):
         default="", description="Unique account identifier for MetaAPI provisioning"
     )
 
+    # ── TickerAll (hosted MT5 API - https://tickerall.com) ───────────────────────
+    tickerall_api_key: SecretStr = Field(
+        default="",
+        description="TickerAll hosted MT5 API key (cf_api_...). When set, TickerAll "
+        "is used as the cloud provider (preferred over MetaAPI); runs on any OS "
+        "with no local terminal.",
+    )
+    tickerall_account_id: SecretStr = Field(
+        default="",
+        description="TickerAll connected-account id. Optional: if omitted and the "
+        "key has a single account, it is used automatically.",
+    )
+
     # ── Trading parameters ─────────────────────────────────────────────────────
     symbol: str = Field(
         default="XAUUSD",
@@ -130,9 +143,15 @@ class TradingConfig(BaseSettings):
     allocator_max_total_heat: float = Field(default=0.70, description="Max 70% of budget committed")
     allocator_max_symbol_risk: float = Field(default=0.40, description="Max 40% per symbol")
     allocator_max_family_risk: float = Field(default=0.40, description="Max 40% per model family")
-    allocator_performance_step: float = Field(default=0.05, description="Adjustment step for performance")
-    allocator_decay_rate: float = Field(default=0.001, description="Rate at which multiplier returns to 1.0")
-    allocator_soft_limit_buffer: float = Field(default=0.10, description="Buffer for diversification guard")
+    allocator_performance_step: float = Field(
+        default=0.05, description="Adjustment step for performance"
+    )
+    allocator_decay_rate: float = Field(
+        default=0.001, description="Rate at which multiplier returns to 1.0"
+    )
+    allocator_soft_limit_buffer: float = Field(
+        default=0.10, description="Buffer for diversification guard"
+    )
 
     # Volatility Thresholds
     volatility_high_threshold: float = Field(

--- a/src/trading/mt5_connector.py
+++ b/src/trading/mt5_connector.py
@@ -48,6 +48,7 @@ from src.core.exceptions import (
 from src.core.resilience import CircuitBreaker
 from src.core.retry import with_retry
 from src.core.schemas import TradeSignal
+from src.trading.tickerall_backend import TickerAllBackend
 
 # Apply nest_asyncio to allow nested loops (MetaAPI SDK uses asyncio)
 nest_asyncio.apply()
@@ -93,9 +94,7 @@ class MT5Connector:
     Supports both native Windows SDK and MetaAPI cloud fallback for cross-platform support.
     """
 
-    def __init__(
-        self, config: TradingConfig, monitor: Optional["Monitor"] = None
-    ) -> None:
+    def __init__(self, config: TradingConfig, monitor: Optional["Monitor"] = None) -> None:
         """
         Initialize the connector with configuration.
 
@@ -109,6 +108,8 @@ class MT5Connector:
         self.metaapi: Any | None = None
         self.metaapi_account: Any | None = None
         self.metaapi_connection: Any | None = None
+        self.use_tickerall: bool = False
+        self.tickerall: TickerAllBackend | None = None
         self._is_initialized: bool = False
         self._background_tasks: set[asyncio.Task] = set()
 
@@ -162,6 +163,7 @@ class MT5Connector:
             mt5_server=self.cfg.mt5_server,
         )
         self.use_metaapi = False  # Reset state
+        self.use_tickerall = False
 
         # 1. Attempt Native MT5 SDK (Primary Path - Windows only)
         if MT5_AVAILABLE:
@@ -203,7 +205,28 @@ class MT5Connector:
                 reason="SDK not imported or platform incompatible",
             )
 
-        # 2. Attempt MetaAPI Cloud (Fallback Path - Linux/Mac/Cloud)
+        # 2. Attempt TickerAll hosted API (opt-in cloud path, preferred over
+        #    MetaAPI when configured). Runs on any OS with no local terminal.
+        tickerall_key = (
+            self.cfg.tickerall_api_key.get_secret_value() if self.cfg.tickerall_api_key else ""
+        )
+        if tickerall_key:
+            logger.info("tickerall_initialization_attempt")
+            try:
+                self.tickerall = TickerAllBackend(self.cfg)
+                self.tickerall.initialize()
+                self.use_tickerall = True
+                self._is_initialized = True
+                logger.info("tickerall_initialization_success")
+                return True
+            except Exception as e:
+                logger.error("tickerall_initialization_failed", error=str(e))
+                raise MT5ConnectionError(
+                    f"TickerAll initialization failed: {e}",
+                    details={"error_type": type(e).__name__},
+                ) from e
+
+        # 3. Attempt MetaAPI Cloud (Fallback Path - Linux/Mac/Cloud)
         metaapi_token = self.cfg.metaapi_token.get_secret_value() if self.cfg.metaapi_token else ""
         if METAAPI_AVAILABLE and metaapi_token and self.cfg.metaapi_account_id:
             logger.info("metaapi_fallback_initialization_attempt")
@@ -256,7 +279,9 @@ class MT5Connector:
     def shutdown(self) -> None:
         """Gracefully close all connections."""
         if self._is_initialized:
-            if not self.use_metaapi and MT5_AVAILABLE:
+            if self.use_tickerall and self.tickerall:
+                self.tickerall.shutdown()
+            elif not self.use_metaapi and MT5_AVAILABLE:
                 mt5.shutdown()
             elif self.use_metaapi and self.metaapi_connection:
                 asyncio.run(self.metaapi_connection.close())
@@ -312,6 +337,9 @@ class MT5Connector:
             logger.info("mt5_connector_auto_initialization")
             self.initialize()
 
+        if self.use_tickerall:
+            return self.tickerall.get_rates(symbol, timeframe, n_bars)
+
         tf = TIMEFRAME_MAP.get(timeframe, 5)
 
         try:
@@ -338,7 +366,6 @@ class MT5Connector:
                 df["time"] = pd.to_datetime(df["time"], unit="s")
                 return df
             else:
-
                 candles = self._run_async(
                     self.metaapi_connection.get_historical_candles(symbol, timeframe, None, n_bars)
                 )
@@ -355,9 +382,7 @@ class MT5Connector:
             raise MT5DataError(f"Unexpected data retrieval error: {e}") from e
 
     @with_retry((MT5DataError, MT5ConnectionError), max_retries=3)
-    def get_ticks_range(
-        self, symbol: str, date_from: datetime, date_to: datetime
-    ) -> pd.DataFrame:
+    def get_ticks_range(self, symbol: str, date_from: datetime, date_to: datetime) -> pd.DataFrame:
         """
         Fetch historical tick data for a specific date range.
 
@@ -376,6 +401,9 @@ class MT5Connector:
     ) -> pd.DataFrame:
         if not self._is_initialized:
             self.initialize()
+
+        if self.use_tickerall:
+            return self.tickerall.get_ticks_range(symbol, date_from, date_to)
 
         try:
             if not self.use_metaapi:
@@ -427,6 +455,9 @@ class MT5Connector:
     ) -> pd.DataFrame:
         if not self._is_initialized:
             self.initialize()
+
+        if self.use_tickerall:
+            return self.tickerall.get_rates_range(symbol, timeframe, date_from, date_to)
 
         tf = TIMEFRAME_MAP.get(timeframe, 5)
 
@@ -481,6 +512,9 @@ class MT5Connector:
     def _get_tick_logic(self, symbol: str) -> Dict[str, float]:
         if not self._is_initialized:
             self.initialize()
+
+        if self.use_tickerall:
+            return self.tickerall.get_tick(symbol)
 
         try:
             if not self.use_metaapi:
@@ -542,6 +576,9 @@ class MT5Connector:
             lots=signal.lot_size,
             algo=signal.algorithm,
         )
+
+        if self.use_tickerall:
+            return self.tickerall.place_order(signal)
 
         order_type = ORDER_TYPE_BUY if signal.direction > 0 else ORDER_TYPE_SELL
 
@@ -655,6 +692,9 @@ class MT5Connector:
         if not self._is_initialized:
             self.initialize()
 
+        if self.use_tickerall:
+            return self.tickerall.get_account_info()
+
         if not self.use_metaapi:
             acc = mt5.account_info()
             if acc is None:
@@ -679,6 +719,9 @@ class MT5Connector:
         """Internal positions retrieval logic."""
         if not self._is_initialized:
             self.initialize()
+
+        if self.use_tickerall:
+            return self.tickerall.get_positions(symbol)
 
         if not self.use_metaapi:
             positions = mt5.positions_get(symbol=symbol) if symbol else mt5.positions_get()
@@ -708,6 +751,9 @@ class MT5Connector:
         if not self._is_initialized:
             self.initialize()
 
+        if self.use_tickerall:
+            return self.tickerall.get_terminal_status()
+
         if not self.use_metaapi:
             info = mt5.terminal_info()
             if not info:
@@ -735,13 +781,18 @@ class MT5Connector:
         if not self._is_initialized:
             self.initialize()
 
+        if self.use_tickerall:
+            return self.tickerall.get_symbol_properties(symbol)
+
         if not self.use_metaapi:
             info = mt5.symbol_info(symbol)
             if not info:
                 err_code, err_desc = mt5.last_error()
                 if err_code in [-1, 10001, 10002, 10003, 10004]:
                     self._is_initialized = False
-                raise MT5DataError(f"Failed to get symbol info for {symbol}: {err_desc} (code: {err_code})")
+                raise MT5DataError(
+                    f"Failed to get symbol info for {symbol}: {err_desc} (code: {err_code})"
+                )
             return {
                 "name": info.name,
                 "tradable": info.trade_mode != mt5.SYMBOL_TRADE_MODE_DISABLED,
@@ -764,7 +815,9 @@ class MT5Connector:
                 }
             except Exception as e:
                 self._is_initialized = False
-                raise MT5DataError(f"MetaAPI get_symbol_specification failed for {symbol}: {e}") from e
+                raise MT5DataError(
+                    f"MetaAPI get_symbol_specification failed for {symbol}: {e}"
+                ) from e
 
     @with_retry((MT5DataError, MT5ConnectionError), max_retries=3)
     def find_symbols(self, pattern: str) -> List[str]:
@@ -776,13 +829,18 @@ class MT5Connector:
         if not self._is_initialized:
             self.initialize()
 
+        if self.use_tickerall:
+            return self.tickerall.find_symbols(pattern)
+
         if not self.use_metaapi:
             symbols = mt5.symbols_get(pattern)
             if symbols is None:
                 err_code, err_desc = mt5.last_error()
                 if err_code in [-1, 10001, 10002, 10003, 10004]:
                     self._is_initialized = False
-                raise MT5DataError(f"Failed to find symbols with pattern {pattern}: {err_desc} (code: {err_code})")
+                raise MT5DataError(
+                    f"Failed to find symbols with pattern {pattern}: {err_desc} (code: {err_code})"
+                )
             return [s.name for s in symbols]
         else:
             # For MetaAPI, we'd need to fetch all and filter, which is slow.

--- a/src/trading/tickerall_backend.py
+++ b/src/trading/tickerall_backend.py
@@ -1,0 +1,328 @@
+"""
+MT5 AI/ML Trading Bot
+src/trading/tickerall_backend.py
+
+TickerAll hosted-API backend for MT5Connector - an opt-in third path alongside
+the native MetaTrader5 SDK and the MetaAPI cloud fallback. When
+`tickerall_api_key` is configured, the bot talks to the hosted TickerAll MT5 API
+(https://tickerall.com) instead of a local terminal, so it runs on any OS with
+no MetaTrader 5 installed. Every method returns data in the SAME shape as the
+native / MetaAPI paths, so MT5Connector stays a drop-in.
+
+License: MIT
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from fnmatch import fnmatch
+from typing import Any, Dict, List, Optional
+
+import pandas as pd
+import structlog
+
+from src.core.exceptions import MT5ConnectionError, MT5DataError, MT5ExecutionError
+
+logger = structlog.get_logger(__name__)
+
+# Timeframes the hosted API serves (superset of the bot's TIMEFRAME_MAP keys).
+_TICKERALL_TIMEFRAMES = {"M1", "M5", "M15", "M30", "H1", "H4", "D1", "W1", "MN1"}
+_TF_MINUTES: Dict[str, int] = {
+    "M1": 1,
+    "M5": 5,
+    "M15": 15,
+    "M30": 30,
+    "H1": 60,
+    "H4": 240,
+    "D1": 1440,
+    "W1": 10080,
+    "MN1": 43200,
+}
+_MAX_RATES_FETCH = 20000
+SYMBOL_TRADE_MODE_DISABLED = 0
+
+
+class TickerAllBackend:
+    """Serves the MT5Connector operations from the hosted TickerAll MT5 API."""
+
+    def __init__(self, cfg: Any) -> None:
+        self.cfg = cfg
+        self._client: Any = None
+        self._account_id: Optional[str] = None
+        self._stream: Any = None
+        self._subscribed: set[str] = set()
+
+    # ── lifecycle ────────────────────────────────────────────────────────────
+    def initialize(self) -> None:
+        """Create the client and resolve the account. Raises on failure."""
+        try:
+            from tickerall import Tickerall
+        except ImportError as e:
+            raise MT5ConnectionError(
+                "The 'tickerall' package is required for the TickerAll backend "
+                "(pip install tickerall)."
+            ) from e
+
+        api_key = self._secret(self.cfg.tickerall_api_key)
+        if not api_key:
+            raise MT5ConnectionError("tickerall_api_key is not configured.")
+
+        self._client = Tickerall(api_key=api_key)
+        self._account_id = self._resolve_account()
+
+    def _resolve_account(self) -> str:
+        configured = self._secret(self.cfg.tickerall_account_id)
+        if configured:
+            return configured
+        accounts = self._client.accounts.list()
+        if len(accounts) == 1:
+            return accounts[0].id
+        if not accounts:
+            raise MT5ConnectionError(
+                "No accounts are connected to this TickerAll API key. Connect one, "
+                "or set tickerall_account_id."
+            )
+        ids = ", ".join(f"{a.id} ({a.server})" for a in accounts)
+        raise MT5ConnectionError(
+            f"This TickerAll key has several accounts; set tickerall_account_id to one of: {ids}"
+        )
+
+    def shutdown(self) -> None:
+        try:
+            if self._stream is not None:
+                self._stream.close()
+                self._stream = None
+            if self._client is not None:
+                self._client.close()
+                self._client = None
+        except Exception as e:
+            logger.warning("tickerall_shutdown_warning", error=str(e))
+
+    # ── market data ──────────────────────────────────────────────────────────
+    def get_rates(self, symbol: str, timeframe: str, n_bars: int) -> pd.DataFrame:
+        bars = self._client.candles.get(
+            self._account_id, symbol=symbol, count=n_bars, timeframe=self._tf(timeframe)
+        )
+        return self._candles_df(bars)
+
+    def get_rates_range(
+        self, symbol: str, timeframe: str, date_from: datetime, date_to: datetime
+    ) -> pd.DataFrame:
+        tf = self._tf(timeframe)
+        frm, to = self._to_epoch(date_from), self._to_epoch(date_to)
+        span = max(1, (to - frm) // (_TF_MINUTES.get(tf, 1) * 60)) + 8
+        bars = self._client.candles.get(
+            self._account_id, symbol=symbol, count=min(span, _MAX_RATES_FETCH), timeframe=tf
+        )
+        bars = [b for b in bars if frm <= self._ts(b.timestamp) <= to]
+        if not bars:
+            raise MT5DataError(
+                f"No {timeframe} bars available for {symbol} in the requested range."
+            )
+        return self._candles_df(bars)
+
+    def get_ticks_range(self, symbol: str, date_from: datetime, date_to: datetime) -> pd.DataFrame:
+        # Historical raw ticks are not served by the hosted API (yet). Be honest
+        # rather than returning fabricated/empty data.
+        raise MT5DataError(
+            "Historical raw ticks are not available via the TickerAll hosted "
+            "provider; use get_rates for OHLC.",
+            is_retriable=False,
+        )
+
+    def get_tick(self, symbol: str) -> Dict[str, float]:
+        bid, ask = self._latest_bid_ask(symbol)
+        return {"bid": bid, "ask": ask, "spread": ask - bid}
+
+    def _latest_bid_ask(self, symbol: str) -> tuple[float, float]:
+        stream = self._ensure_stream()
+        if symbol not in self._subscribed:
+            stream.subscribe_ticks(self._account_id, [symbol])
+            self._subscribed.add(symbol)
+        try:
+            ev = stream.wait_for_tick(symbol, account_id=self._account_id, timeout=6.0)
+            return float(ev.bid), float(ev.ask)
+        except Exception:
+            bars = self._client.candles.get(
+                self._account_id, symbol=symbol, count=1, timeframe="M1"
+            )
+            if bars:
+                b = bars[-1]
+                return float(b.bid or b.close), float(b.close)
+            raise MT5DataError(f"No tick available for {symbol}.") from None
+
+    def _ensure_stream(self) -> Any:
+        if self._stream is None or not self._stream.is_connected():
+            self._stream = self._client.stream.connect(timeout=15.0)
+            self._subscribed = set()
+        return self._stream
+
+    # ── trading ──────────────────────────────────────────────────────────────
+    def place_order(self, signal: Any) -> Optional[int]:
+        side = "BUY" if signal.direction > 0 else "SELL"
+        try:
+            result = self._client.orders.place(
+                self._account_id,
+                type="market",
+                symbol=signal.symbol,
+                side=side,
+                volume=signal.lot_size,
+                stop_loss=float(signal.stop_loss) if signal.stop_loss else None,
+                take_profit=float(signal.take_profit) if signal.take_profit else None,
+                comment=f"AI:{signal.algorithm}",
+            )
+            logger.info(
+                "tickerall_order_placement_success",
+                symbol=signal.symbol,
+                ticket=result.ticket,
+            )
+            return int(result.ticket)
+        except Exception as e:
+            msg = str(e).lower()
+            if any(k in msg for k in ("unreachable", "timeout", "not hot", "connection", "503")):
+                raise MT5ConnectionError(f"TickerAll connection lost during order: {e}") from e
+            raise MT5ExecutionError(f"TickerAll order placement failed: {e}") from e
+
+    # ── account / positions ──────────────────────────────────────────────────
+    def get_account_info(self) -> Dict[str, Any]:
+        detail = self._client.accounts.get(self._account_id)
+        acc = detail.account
+        if acc is None:
+            raise MT5DataError(
+                f"TickerAll account snapshot unavailable: {detail.hint or 'offline'}"
+            )
+        balance = acc.balance
+        # equity/margin may be absent (None) - distinct from a real 0.0 value.
+        equity = acc.equity if acc.equity is not None else balance
+        margin = acc.margin if acc.margin is not None else 0.0
+        margin_free = acc.free_margin if acc.free_margin is not None else equity
+        digits = "".join(c for c in detail.account_number if c.isdigit())
+        return {
+            "login": int(digits) if digits else 0,
+            "balance": balance,
+            "equity": equity,
+            "margin": margin,
+            "margin_free": margin_free,
+            "margin_level": acc.margin_level if acc.margin_level is not None else 0.0,
+            "profit": (equity - balance) if acc.equity is not None else 0.0,
+            "currency": acc.currency or "",
+            "leverage": acc.leverage,
+            "name": acc.name,
+            "server": detail.server,
+            "company": acc.broker_name or detail.broker,
+        }
+
+    def get_positions(self, symbol: Optional[str] = None) -> List[Dict[str, Any]]:
+        detail = self._client.accounts.get(self._account_id)
+        out: List[Dict[str, Any]] = []
+        for p in detail.positions:
+            if symbol and p.symbol != symbol:
+                continue
+            out.append(self._position_dict(p))
+        return out
+
+    def get_terminal_status(self) -> Dict[str, Any]:
+        # Hosted API has no local terminal button; a connected session can trade.
+        return {"algo_trading": True, "connected": True}
+
+    def get_symbol_properties(self, symbol: str) -> Dict[str, Any]:
+        spec = next(
+            (s for s in self._client.accounts.symbol_specs(self._account_id) if s.name == symbol),
+            None,
+        )
+        if spec is None:
+            raise MT5DataError(f"Symbol {symbol} not found via TickerAll.")
+        tradable = (
+            True if spec.trade_mode is None else spec.trade_mode != SYMBOL_TRADE_MODE_DISABLED
+        )
+        return {
+            "name": spec.name,
+            "tradable": tradable,
+            "spread": 0,
+            "digits": spec.digits if spec.digits is not None else 0,
+            "point": spec.point,
+            "trade_contract_size": spec.contract_size,
+        }
+
+    def find_symbols(self, pattern: str) -> List[str]:
+        names = self._client.accounts.symbols(self._account_id)
+        glob = pattern if any(c in pattern for c in "*?[") else f"*{pattern}*"
+        return [n for n in names if fnmatch(n.upper(), glob.upper())]
+
+    # ── helpers ──────────────────────────────────────────────────────────────
+    def _tf(self, timeframe: str) -> str:
+        tf = str(timeframe).upper()
+        if tf not in _TICKERALL_TIMEFRAMES:
+            raise MT5DataError(
+                f"Timeframe {timeframe} is not available via the TickerAll hosted "
+                f"provider (supported: {', '.join(sorted(_TICKERALL_TIMEFRAMES))}).",
+                is_retriable=False,
+            )
+        return tf
+
+    @staticmethod
+    def _candles_df(bars: Any) -> pd.DataFrame:
+        if not bars:
+            return pd.DataFrame()
+        rows = [
+            {
+                "time": TickerAllBackend._ts(b.timestamp),
+                "open": b.open,
+                "high": b.high,
+                "low": b.low,
+                "close": b.close,
+                "tick_volume": b.tick_volume,
+                "spread": int(b.spread) if b.spread is not None else 0,
+                "real_volume": 0,
+            }
+            for b in sorted(bars, key=lambda x: x.timestamp)
+        ]
+        df = pd.DataFrame(rows)
+        df["time"] = pd.to_datetime(df["time"], unit="s")
+        return df
+
+    @staticmethod
+    def _position_dict(p: Any) -> Dict[str, Any]:
+        t = TickerAllBackend._ts(p.open_time)
+        return {
+            "ticket": int(p.ticket),
+            "time": t,
+            "type": 0 if str(p.side).upper() == "BUY" else 1,
+            "magic": p.magic,
+            "identifier": int(p.ticket),
+            "volume": p.volume,
+            "price_open": p.entry_price if p.entry_price is not None else 0.0,
+            "sl": p.stop_loss,
+            "tp": p.take_profit,
+            "price_current": p.current_price if p.current_price is not None else 0.0,
+            "swap": p.swap,
+            "profit": p.profit if p.profit is not None else 0.0,
+            "symbol": p.symbol,
+            "comment": p.comment,
+        }
+
+    @staticmethod
+    def _secret(value: Any) -> str:
+        if value is None:
+            return ""
+        if hasattr(value, "get_secret_value"):
+            return value.get_secret_value()
+        return str(value)
+
+    @staticmethod
+    def _ts(value: Any) -> int:
+        if value is None or value == "":
+            return 0
+        if isinstance(value, (int, float)):
+            return int(value)
+        try:
+            return int(datetime.fromisoformat(str(value).replace("Z", "+00:00")).timestamp())
+        except (ValueError, TypeError):
+            return 0
+
+    @staticmethod
+    def _to_epoch(value: Any) -> int:
+        if isinstance(value, datetime):
+            dt = value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+            return int(dt.timestamp())
+        return TickerAllBackend._ts(value)


### PR DESCRIPTION
Closes #1711

## What

An opt-in third cloud path for `MT5Connector`: the hosted
[TickerAll](https://tickerall.com) MT5 API. Set `tickerall_api_key` and it
becomes the cloud provider (preferred over MetaAPI); leave it unset and nothing
changes. Runs on any OS with no local terminal and no MetaAPI subscription.

## How

- **`src/trading/tickerall_backend.py`** - a self-contained `TickerAllBackend`
  that maps every `MT5Connector` operation (rates, ticks, tick, account,
  positions, order placement, symbol properties, symbol search) onto the public
  [`tickerall`](https://pypi.org/project/tickerall/) SDK, returning the SAME
  shapes (DataFrames / dicts) as the native and MetaAPI paths - so the connector
  stays a drop-in.
- **`src/trading/mt5_connector.py`** - a `use_tickerall` path selected in
  `_initialize_logic` (native -> tickerall -> metaapi), a one-line delegation
  per method, plus shutdown handling.
- **`src/core/config.py`** - `tickerall_api_key` + `tickerall_account_id`
  settings, mirroring the existing MetaAPI fields.
- `tickerall` added to the dependency lists alongside `metaapi-cloud-sdk`.

## Honest about limits

Historical raw ticks (`get_ticks_range`) are not served by the hosted API and
raise a clear error rather than returning fabricated or empty data.

## Verification

- `ruff check` + `ruff format --check` clean (the repo's pinned `0.15.22`
  config).
- Live end-to-end against a demo account, through the real `MT5Connector`:
  connect (`use_tickerall` active), account info, symbol properties,
  `find_symbols`, H1 rates (columns matching the native shape), rates-range,
  live tick, positions, terminal status, and a market **open -> close**
  round-trip via `place_order`.
- With `tickerall_api_key` unset, the native / MetaAPI behaviour is completely
  unchanged.
