### PR TITLE
docs: update daily merge-readiness checklist [2026-07-29]

### DIFF
--- a/docs/status/MERGE_READY_CHECKLIST.md
+++ b/docs/status/MERGE_READY_CHECKLIST.md
@@ -1,9 +1,9 @@
 # Merge-Readiness Checklist
 
 > [!IMPORTANT]
-> **Critical Repository State Notice:** The `main` branch is currently operating under a history-grafting model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `74e732bd05983f1e61c581e958e866913735cb54` is required for all PRs.**
+> **Critical Repository State Notice:** The `main` branch is currently operating under a history-grafting model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `5698f7b7f7dc1df30012d044a44c6d0fb5e6e964` is required for all PRs.**
 
-Generated on: 2026-07-29 13:30:52 UTC
+Generated on: 2026-07-29 14:11:28 UTC
 
 This checklist identifies top promising PRs for immediate review.
 
@@ -11,21 +11,21 @@ This checklist identifies top promising PRs for immediate review.
 - **Short scope summary**: Medium Risk update implementing 'chore(deps): bump types-setuptools from 83.0.0.20260716 to 83.0.0.20260724' (Candidate for re-validation/review)
 - **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `74e732bd05983f1e61c581e958e866913735cb54`, tests, docs
+- **Missing items**: Mandatory rebase against commit `5698f7b7f7dc1df30012d044a44c6d0fb5e6e964`, tests, docs
 - **Recommendation**: Needs CI success before merge
 
 ## 2. PR #1723: chore(deps): bump prometheus-client from 0.25.0 to 0.26.0
 - **Short scope summary**: Medium Risk update implementing 'chore(deps): bump prometheus-client from 0.25.0 to 0.26.0' (Candidate for re-validation/review)
 - **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `74e732bd05983f1e61c581e958e866913735cb54`, tests, docs
+- **Missing items**: Mandatory rebase against commit `5698f7b7f7dc1df30012d044a44c6d0fb5e6e964`, tests, docs
 - **Recommendation**: Needs CI success before merge
 
 ## 3. PR #1721: chore(deps): bump fastapi from 0.139.2 to 0.140.0
 - **Short scope summary**: Medium Risk update implementing 'chore(deps): bump fastapi from 0.139.2 to 0.140.0' (Candidate for re-validation/review)
 - **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `74e732bd05983f1e61c581e958e866913735cb54`, tests, docs
+- **Missing items**: Mandatory rebase against commit `5698f7b7f7dc1df30012d044a44c6d0fb5e6e964`, tests, docs
 - **Recommendation**: Needs CI success before merge
 
 ---

--- a/docs/status/PR_TRIAGE_DAILY.md
+++ b/docs/status/PR_TRIAGE_DAILY.md
@@ -1,6 +1,6 @@
 # Daily PR Triage Dashboard
 
-**Date:** 2026-07-29 13:30:52 UTC
+**Date:** 2026-07-29 14:11:28 UTC
 **Status:** 🔴 HIGH TURBULENCE
 
 ### Turbulence Factors:
@@ -10,7 +10,7 @@
 
 ## 🔝 Top 3 Items That Matter Right Now
 
-1. **Mandatory Rebase:** All open PRs require a mandatory rebase against commit `74e732bd05983f1e61c581e958e866913735cb54` to ensure compatibility.
+1. **Mandatory Rebase:** All open PRs require a mandatory rebase against commit `5698f7b7f7dc1df30012d044a44c6d0fb5e6e964` to ensure compatibility.
 2. **Address Turbulence:** High number of open PRs (566)
 3. **Re-validate Stale:** Review Safe Surface PR #1720 (chore(deps): bump tqdm from 4.68.4 to 4.69.1)
 


### PR DESCRIPTION
This daily update refreshes the Daily PR Triage Dashboard and Merge-Readiness Checklist. It establishes the latest main branch commit 5698f7b7f7dc1df30012d044a44c6d0fb5e6e964 as the mandatory rebase target, reports risk-triage profiles on the active PR backlog, and recommends top low-to-medium-risk candidates for easy review.

---
*PR created automatically by Jules for task [17397376319939205651](https://jules.google.com/task/17397376319939205651) started by @triqbit*