### PR TITLE
docs: update daily merge-readiness checklist and PR triage dashboard [2026-07-30]

### DIFF
--- a/docs/status/MERGE_READY_CHECKLIST.md
+++ b/docs/status/MERGE_READY_CHECKLIST.md
@@ -1,31 +1,31 @@
 # Merge-Readiness Checklist
 
 > [!IMPORTANT]
-> **Critical Repository State Notice:** The `main` branch is currently operating under a history-grafting model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `16014eceb84c4f18ea3fcbb5f5ad747dd63e69b6` is required for all PRs.**
+> **Critical Repository State Notice:** The `main` branch is currently operating under a history-grafting model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `325ca0e4d1542ecafb1f806ab49139672ea53afe` is required for all PRs.**
 
-Generated on: 2026-07-30 13:11:39 UTC
+Generated on: 2026-07-30 14:20:45 UTC
 
 This checklist identifies top promising PRs for immediate review.
 
 ## 1. PR #1725: chore(deps): bump types-setuptools from 83.0.0.20260716 to 83.0.0.20260724
-- **Short scope summary**: Medium Risk update implementing 'chore(deps): bump types-setuptools from 83.0.0.20260716 to 83.0.0.20260724' (Candidate for re-validation/review)
-- **Domains touched**: dependencies
+- **Short scope summary**: Safe Surface update implementing 'chore(deps): bump types-setuptools from 83.0.0.20260716 to 83.0.0.20260724' (Candidate for re-validation/review)
+- **Domains touched**: chore, dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `16014eceb84c4f18ea3fcbb5f5ad747dd63e69b6`, tests, docs
+- **Missing items**: Mandatory rebase against commit `325ca0e4d1542ecafb1f806ab49139672ea53afe`
 - **Recommendation**: Needs CI success before merge
 
 ## 2. PR #1723: chore(deps): bump prometheus-client from 0.25.0 to 0.26.0
 - **Short scope summary**: Medium Risk update implementing 'chore(deps): bump prometheus-client from 0.25.0 to 0.26.0' (Candidate for re-validation/review)
-- **Domains touched**: dependencies
+- **Domains touched**: chore, dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `16014eceb84c4f18ea3fcbb5f5ad747dd63e69b6`, tests, docs
+- **Missing items**: Mandatory rebase against commit `325ca0e4d1542ecafb1f806ab49139672ea53afe`, tests, docs
 - **Recommendation**: Needs CI success before merge
 
 ## 3. PR #1721: chore(deps): bump fastapi from 0.139.2 to 0.140.0
 - **Short scope summary**: Medium Risk update implementing 'chore(deps): bump fastapi from 0.139.2 to 0.140.0' (Candidate for re-validation/review)
-- **Domains touched**: dependencies
+- **Domains touched**: chore, dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `16014eceb84c4f18ea3fcbb5f5ad747dd63e69b6`, tests, docs
+- **Missing items**: Mandatory rebase against commit `325ca0e4d1542ecafb1f806ab49139672ea53afe`, tests, docs
 - **Recommendation**: Needs CI success before merge
 
 ---

--- a/docs/status/PR_TRIAGE_DAILY.md
+++ b/docs/status/PR_TRIAGE_DAILY.md
@@ -1,6 +1,6 @@
 # Daily PR Triage Dashboard
 
-**Date:** 2026-07-30 13:11:39 UTC
+**Date:** 2026-07-30 14:20:45 UTC
 **Status:** 🔴 HIGH TURBULENCE
 
 ### Turbulence Factors:
@@ -10,15 +10,15 @@
 
 ## 🔝 Top 3 Items That Matter Right Now
 
-1. **Mandatory Rebase:** All open PRs require a mandatory rebase against commit `16014eceb84c4f18ea3fcbb5f5ad747dd63e69b6` to ensure compatibility.
+1. **Mandatory Rebase:** All open PRs require a mandatory rebase against commit `325ca0e4d1542ecafb1f806ab49139672ea53afe` to ensure compatibility.
 2. **Address Turbulence:** High number of open PRs (566)
-3. **Re-validate Stale:** Review Safe Surface PR #1720 (chore(deps): bump tqdm from 4.68.4 to 4.69.1)
+3. **Re-validate Stale:** Review Safe Surface PR #1725 (chore(deps): bump types-setuptools from 83.0.0.20260716 to 83.0.0.20260724)
 
 ## 📋 Summary Table
 
 | PR # | Title | Author | Branch | Labels | CI Status | Risk Class | Status Flag |
 |------|-------|--------|--------|--------|-----------|------------|-------------|
-| [1725](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1725) | chore(deps): bump types-setuptools from 83.0.0.20260716 to 83.0.0.20260724 | dependabot[bot] | `dependabot/pip/types-setuptools-83.0.0.20260724` | none | pending | Medium Risk | ⚠️ Stale (Pre-Big-Bang) |
+| [1725](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1725) | chore(deps): bump types-setuptools from 83.0.0.20260716 to 83.0.0.20260724 | dependabot[bot] | `dependabot/pip/types-setuptools-83.0.0.20260724` | none | pending | Safe Surface | ⚠️ Stale (Pre-Big-Bang) |
 | [1723](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1723) | chore(deps): bump prometheus-client from 0.25.0 to 0.26.0 | dependabot[bot] | `dependabot/pip/prometheus-client-0.26.0` | none | pending | Medium Risk | ⚠️ Stale (Pre-Big-Bang) |
 | [1721](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1721) | chore(deps): bump fastapi from 0.139.2 to 0.140.0 | dependabot[bot] | `dependabot/pip/fastapi-0.140.0` | none | pending | Medium Risk | ⚠️ Stale (Pre-Big-Bang) |
 | [1720](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1720) | chore(deps): bump tqdm from 4.68.4 to 4.69.1 | dependabot[bot] | `dependabot/pip/tqdm-4.69.1` | none | pending | Safe Surface | ⚠️ Stale (Pre-Big-Bang) |
@@ -26,7 +26,7 @@
 | [1697](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1697) | docs: update process integrity log [2026-07-21] | triqbit | `process-integrity-log-2026-07-21-qufuwan-17949035639015288261` | none | pending | Safe Surface | ⚠️ Stale (Pre-Big-Bang) |
 | [1681](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1681) | feat(atlas): implement multi-agent LLM macro overlay architecture | showmeyourmind | `feature/atlas-hybrid-integration` | none | pending | High Risk | ⚠️ Stale (Pre-Big-Bang) |
 | [1661](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1661) | DX: update process integrity log and project health [2026-07-14] | triqbit | `dx-process-integrity-update-2026-07-14-12746976662363800520` | none | pending | Safe Surface | ⚠️ Stale (Pre-Big-Bang) |
-| [1653](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1653) | chore(deps): bump uvicorn from 0.50.0 to 0.51.0 | dependabot[bot] | `dependabot/pip/uvicorn-0.51.0` | none | pending | Medium Risk | ⚠️ Stale (Pre-Big-Bang) |
+| [1653](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1653) | chore(deps): bump uvicorn from 0.50.0 to 0.51.0 | dependabot[bot] | `dependabot/pip/uvicorn-0.51.0` | none | unknown | Safe Surface | ⚠️ Stale (Pre-Big-Bang) |
 | [1576](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1576) | DX: improve developer onboarding and contribution experience | triqbit | `dx-improve-onboarding-credibility-5459078260715495313` | escalated-risk | pending | High Risk | ⚠️ Stale (Pre-Big-Bang) |
 | [1543](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1543) | DX: improve developer onboarding and contribution experience | triqbit | `dx-daily-triage-2026-06-20-qufuwan-7504956792826488201` | none | pending | Safe Surface | ⚠️ Stale (Pre-Big-Bang) |
 | [1528](https://github.com/triqbit/mt5-ai-xauusd-trader/pull/1528) | docs: improve developer onboarding and contribution experience | triqbit | `dx-process-integrity-log-2026-06-16-5084547163796099815` | none | pending | Safe Surface | ⚠️ Stale (Pre-Big-Bang) |
@@ -595,7 +595,7 @@
 
 ## ✨ Good Candidates for Review Today
 
-- **PR #1725**: chore(deps): bump types-setuptools from 83.0.0.20260716 to 83.0.0.20260724 (dependabot[bot]) [CI: pending] - *Medium Risk*
+- **PR #1725**: chore(deps): bump types-setuptools from 83.0.0.20260716 to 83.0.0.20260724 (dependabot[bot]) [CI: pending] - *Safe Surface*
 - **PR #1723**: chore(deps): bump prometheus-client from 0.25.0 to 0.26.0 (dependabot[bot]) [CI: pending] - *Medium Risk*
 - **PR #1721**: chore(deps): bump fastapi from 0.139.2 to 0.140.0 (dependabot[bot]) [CI: pending] - *Medium Risk*
 - **PR #1720**: chore(deps): bump tqdm from 4.68.4 to 4.69.1 (dependabot[bot]) [CI: pending] - *Safe Surface*


### PR DESCRIPTION
Updated the Daily PR Triage Dashboard and Merge-Readiness Checklist under docs/status/ for July 30, 2026, establishing 325ca0e4d1542ecafb1f806ab49139672ea53afe as the mandatory rebase target, updating timestamps, and classifying and assessing candidate PRs for Jules05 and human review.

---
*PR created automatically by Jules for task [6717818041315487584](https://jules.google.com/task/6717818041315487584) started by @triqbit*