### PR TITLE
docs: update daily merge-ready checklist and PR triage [2026-08-04]

### DIFF
--- a/docs/status/MERGE_READY_CHECKLIST.md
+++ b/docs/status/MERGE_READY_CHECKLIST.md
@@ -1,31 +1,31 @@
 # Merge-Readiness Checklist
 
 > [!IMPORTANT]
-> **Critical Repository State Notice:** The `main` branch is currently operating under a history-grafting model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `c32de6f68042e5be9640604f09cbeeefa6062b19` is required for all PRs.**
+> **Critical Repository State Notice:** The `main` branch is currently operating under a history-grafting model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `95fd8fddd3b62dce70ce2c245d0a11107a4cc45b` is required for all PRs.**
 
-Generated on: 2026-08-04 18:00:00 UTC
+Generated on: 2026-08-04 13:34:01 UTC
 
 This checklist identifies top promising PRs for immediate review.
 
 ## 1. PR #1757: chore(deps): bump fastapi from 0.140.13 to 0.141.1
 - **Short scope summary**: Medium Risk update implementing 'chore(deps): bump fastapi from 0.140.13 to 0.141.1' (Candidate for re-validation/review)
-- **Domains touched**: chore, dependencies
+- **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `c32de6f68042e5be9640604f09cbeeefa6062b19`, tests, docs
+- **Missing items**: Mandatory rebase against commit `95fd8fddd3b62dce70ce2c245d0a11107a4cc45b`, tests, docs
 - **Recommendation**: Needs CI success before merge
 
 ## 2. PR #1754: chore(deps): bump hypothesis from 6.161.5 to 6.164.0
-- **Short scope summary**: Safe Surface update implementing 'chore(deps): bump hypothesis from 6.161.5 to 6.164.0' (Candidate for re-validation/review)
-- **Domains touched**: chore, dependencies
+- **Short scope summary**: Medium Risk update implementing 'chore(deps): bump hypothesis from 6.161.5 to 6.164.0' (Candidate for re-validation/review)
+- **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `c32de6f68042e5be9640604f09cbeeefa6062b19`
+- **Missing items**: Mandatory rebase against commit `95fd8fddd3b62dce70ce2c245d0a11107a4cc45b`, tests, docs
 - **Recommendation**: Needs CI success before merge
 
 ## 3. PR #1752: chore(deps): bump types-pyyaml from 6.0.12.20260518 to 6.0.12.20260724
-- **Short scope summary**: Safe Surface update implementing 'chore(deps): bump types-pyyaml from 6.0.12.20260518 to 6.0.12.20260724' (Candidate for re-validation/review)
-- **Domains touched**: chore, dependencies
+- **Short scope summary**: Medium Risk update implementing 'chore(deps): bump types-pyyaml from 6.0.12.20260518 to 6.0.12.20260724' (Candidate for re-validation/review)
+- **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `c32de6f68042e5be9640604f09cbeeefa6062b19`
+- **Missing items**: Mandatory rebase against commit `95fd8fddd3b62dce70ce2c245d0a11107a4cc45b`, tests, docs
 - **Recommendation**: Needs CI success before merge
 
 ---

--- a/docs/status/PR_TRIAGE_DAILY.md
+++ b/docs/status/PR_TRIAGE_DAILY.md
@@ -1,6 +1,6 @@
 # Daily PR Triage Dashboard
 
-**Date:** 2026-08-04 18:00:00 UTC
+**Date:** 2026-08-04 13:34:01 UTC
 **Status:** 🔴 HIGH TURBULENCE
 
 ### Turbulence Factors:
@@ -10,7 +10,7 @@
 
 ## 🔝 Top 3 Items That Matter Right Now
 
-1. **Mandatory Rebase:** All open PRs require a mandatory rebase against commit `c32de6f68042e5be9640604f09cbeeefa6062b19` to ensure compatibility.
+1. **Mandatory Rebase:** All open PRs require a mandatory rebase against commit `95fd8fddd3b62dce70ce2c245d0a11107a4cc45b` to ensure compatibility.
 2. **Address Turbulence:** High number of open PRs (566)
 3. **Re-validate Stale:** Review Safe Surface PR #1740 (docs: update daily merge-readiness checklist and PR triage [2026-07-31])
 


### PR DESCRIPTION
Generated the daily PR triage snapshot and merge-readiness checklist for August 4, 2026. Reclassified all 566 open PRs, updated the mandatory rebase target commit SHA, highlight good review candidates, and validated that triage diagnostics and heuristics tests pass cleanly in the local environment.

---
*PR created automatically by Jules for task [15710700224895664014](https://jules.google.com/task/15710700224895664014) started by @triqbit*