### PR TITLE
docs: update daily merge-readiness checklist and PR triage [2026-08-06]

### DIFF
--- a/docs/status/MERGE_READY_CHECKLIST.md
+++ b/docs/status/MERGE_READY_CHECKLIST.md
@@ -1,9 +1,9 @@
 # Merge-Readiness Checklist
 
 > [!IMPORTANT]
-> **Critical Repository State Notice:** The `main` branch is currently operating under a history-grafting model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `b5a21f104a051c11c6159cb88a2f8cdbb5fa36c3` is required for all PRs.**
+> **Critical Repository State Notice:** The `main` branch is currently operating under a history-grafting model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `88652ac53a6840a83fa71a228233a1fac8c4b18b` is required for all PRs.**
 
-Generated on: 2026-08-06 13:16:45 UTC
+Generated on: 2026-08-06 14:22:18 UTC
 
 This checklist identifies top promising PRs for immediate review.
 
@@ -11,21 +11,21 @@ This checklist identifies top promising PRs for immediate review.
 - **Short scope summary**: Medium Risk update implementing 'chore(deps): bump fastapi from 0.140.13 to 0.141.1' (Candidate for re-validation/review)
 - **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `b5a21f104a051c11c6159cb88a2f8cdbb5fa36c3`, tests, docs
+- **Missing items**: Mandatory rebase against commit `88652ac53a6840a83fa71a228233a1fac8c4b18b`, tests, docs
 - **Recommendation**: Needs CI success before merge
 
 ## 2. PR #1754: chore(deps): bump hypothesis from 6.161.5 to 6.164.0
 - **Short scope summary**: Medium Risk update implementing 'chore(deps): bump hypothesis from 6.161.5 to 6.164.0' (Candidate for re-validation/review)
 - **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `b5a21f104a051c11c6159cb88a2f8cdbb5fa36c3`, tests, docs
+- **Missing items**: Mandatory rebase against commit `88652ac53a6840a83fa71a228233a1fac8c4b18b`, tests, docs
 - **Recommendation**: Needs CI success before merge
 
 ## 3. PR #1752: chore(deps): bump types-pyyaml from 6.0.12.20260518 to 6.0.12.20260724
 - **Short scope summary**: Medium Risk update implementing 'chore(deps): bump types-pyyaml from 6.0.12.20260518 to 6.0.12.20260724' (Candidate for re-validation/review)
 - **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `b5a21f104a051c11c6159cb88a2f8cdbb5fa36c3`, tests, docs
+- **Missing items**: Mandatory rebase against commit `88652ac53a6840a83fa71a228233a1fac8c4b18b`, tests, docs
 - **Recommendation**: Needs CI success before merge
 
 ---

--- a/docs/status/PR_TRIAGE_DAILY.md
+++ b/docs/status/PR_TRIAGE_DAILY.md
@@ -1,6 +1,6 @@
 # Daily PR Triage Dashboard
 
-**Date:** 2026-08-06 13:16:45 UTC
+**Date:** 2026-08-06 14:22:18 UTC
 **Status:** 🔴 HIGH TURBULENCE
 
 ### Turbulence Factors:
@@ -10,7 +10,7 @@
 
 ## 🔝 Top 3 Items That Matter Right Now
 
-1. **Mandatory Rebase:** All open PRs require a mandatory rebase against commit `b5a21f104a051c11c6159cb88a2f8cdbb5fa36c3` to ensure compatibility.
+1. **Mandatory Rebase:** All open PRs require a mandatory rebase against commit `88652ac53a6840a83fa71a228233a1fac8c4b18b` to ensure compatibility.
 2. **Address Turbulence:** High number of open PRs (566)
 3. **Re-validate Stale:** Review Safe Surface PR #1740 (docs: update daily merge-readiness checklist and PR triage [2026-07-31])
 


### PR DESCRIPTION
Updates the daily PR triage dashboard (docs/status/PR_TRIAGE_DAILY.md) and daily merge-readiness checklist (docs/status/MERGE_READY_CHECKLIST.md) to use commit 88652ac53a6840a83fa71a228233a1fac8c4b18b (PR #1768) as the mandatory rebase target for August 6, 2026. All process invariants are fully satisfied.

---
*PR created automatically by Jules for task [3910637052080760042](https://jules.google.com/task/3910637052080760042) started by @triqbit*