### PR TITLE
docs: update daily process integrity log [2026-08-09]

### DIFF
--- a/docs/status/PROCESS_INTEGRITY_LOG.md
+++ b/docs/status/PROCESS_INTEGRITY_LOG.md
@@ -2,6 +2,26 @@
 
 This log tracks the health and safety of the autonomous workflow for the `mt5-ai-xauusd-trader` repository.
 
+## 2026-08-09 18:00 GMT+4
+
+**Summary:** Process invariants are fully holding on `main`. No process drift or risky behavior detected. One safe-surface documentation and triage update pull request has been integrated since the last process integrity report.
+
+**Suspected Process Issues:**
+- **Stale PR Backlog:** The open PR count is at 566. These are 100% stale relative to the active `main` branch but do not affect current system safety on `main`.
+
+**PRs/Commits Involved:**
+- `main` branch: Commit `2a2db43e3e281a691634a8260c9757546bffb985` (PR #1779) - Updates daily merge-readiness checklist and daily PR triage dashboard, establishing commit `8655060a6ee0a02dfab2cc50fc7c9afd4df77b1b` as the mandatory rebase target.
+
+**Check Invariants:**
+- [x] Changes go through PRs (Verified: The integrated commit utilized a proper PR branch).
+- [x] CI must pass before merge (Verified: Local developer diagnostics are green and clean, CI status is PASSING).
+- [x] Risky domains are not being changed casually (Verified: Only documentation, triage metrics, and checklist files were modified. No trading or risk logic files were touched).
+
+**Recommended Follow-ups:**
+- **Backlog Pruning:** Jules05 should perform a bulk prune/closure of the 566 stale PRs to reduce noise.
+
+**Status:** 🟢 GREEN (Invariants holding, git linear history verified as fully preserved).
+
 ## 2026-08-08 18:00 GMT+4
 
 **Summary:** Process invariants are fully holding on `main`. No process drift or risky behavior detected. Four safe-surface developer experience, documentation, and triage dashboard update pull requests have been integrated since the last process integrity report. Critical out-of-the-box local bootstrap and doctor execution paths are fully restored and stable.


### PR DESCRIPTION
This pull request appends the daily Process Integrity & Drift Watcher report under `docs/status/PROCESS_INTEGRITY_LOG.md` for 2026-08-09 18:00 GMT+4, documenting that workflow safety invariants are fully holding (GREEN) on main.

---
*PR created automatically by Jules for task [12426541785073821471](https://jules.google.com/task/12426541785073821471) started by @triqbit*