### PR TITLE
docs: update daily process integrity log [2026-08-10] (#1792)

### DIFF
--- a/docs/status/PROCESS_INTEGRITY_LOG.md
+++ b/docs/status/PROCESS_INTEGRITY_LOG.md
@@ -2,6 +2,33 @@
 
 This log tracks the health and safety of the autonomous workflow for the `mt5-ai-xauusd-trader` repository.
 
+## 2026-08-10 18:00 GMT+4
+
+**Summary:** Process invariants are fully holding on `main`. No process drift or risky behavior detected. Several safe-surface dependency bumps and daily triage/checklist updates have been safely integrated since the last process integrity report.
+
+**Suspected Process Issues:**
+- **Stale PR Backlog:** The open PR count is at 567. These are 100% stale relative to the active `main` branch but do not affect current system safety on `main`.
+
+**PRs/Commits Involved:**
+- `main` branch: Commit `ed717627d0da709daf61c2516e69af0ef9543cb9` (PR #1791) - Updates daily merge-readiness checklist and PR triage dashboard for 2026-08-10.
+- `main` branch: Commit `4cd9f34aec88138c3ece9dd7e6f1e7dfc92de300` (PR #1790) - Bumps hypothesis from 6.161.5 to 6.165.2.
+- `main` branch: Commit `51fadd00d2622f244ac9714682d5c02306bc8c95` (PR #1787) - Bumps types-python-dateutil.
+- `main` branch: Commit `37c7a96c2c60775427e7a09be97331eecf1a7768` (PR #1752) - Bumps types-pyyaml.
+- `main` branch: Commit `d68d4c6ae9d287489e967d1fafbd339baf292e6a` (PR #1789) - Bumps uvicorn from 0.52.0 to 0.52.1.
+- `main` branch: Commit `8adecfe2b23ec39742b1f11e0b5e0fffc94c9c34` (PR #1785) - Bumps types-setuptools.
+- `main` branch: Commit `85e17460a0c1cd20156341abde85b05e8b59c362` (PR #1783) - Bumps alembic from 1.14.0 to 1.19.0.
+- `main` branch: Commit `47fa54930a7cb0ff51449933d869e1782d44eb2f` (PR #1781) - Updates daily merge-readiness checklist and PR triage for 2026-08-09.
+
+**Check Invariants:**
+- [x] Changes go through PRs (Verified: All integrated commits utilized proper PR branches).
+- [x] CI must pass before merge (Verified: Local developer diagnostics are green and clean, CI status is PASSING).
+- [x] Risky domains are not being changed casually (Verified: Only documentation, triage metrics, configuration, dependency updates, and checklist files were modified. No trading or risk logic files were touched).
+
+**Recommended Follow-ups:**
+- **Backlog Pruning:** Jules05 should perform a bulk prune/closure of the 567 stale PRs to reduce noise.
+
+**Status:** 🟢 GREEN (Invariants holding, git linear history verified as fully preserved).
+
 ## 2026-08-09 18:00 GMT+4
 
 **Summary:** Process invariants are fully holding on `main`. No process drift or risky behavior detected. One safe-surface documentation and triage update pull request has been integrated since the last process integrity report.


### PR DESCRIPTION
Added a daily process integrity log entry under docs/status/PROCESS_INTEGRITY_LOG.md for 2026-08-10 18:00 GMT+4 to keep workflow state documented, verified safety invariants, and checked that local diagnostics/heuristics tests pass cleanly.

---
*PR created automatically by Jules for task [17135330986678343332](https://jules.google.com/task/17135330986678343332) started by @triqbit*