### PR TITLE
docs: update daily merge-readiness checklist and PR triage

### DIFF
--- a/docs/status/MERGE_READY_CHECKLIST.md
+++ b/docs/status/MERGE_READY_CHECKLIST.md
@@ -1,9 +1,9 @@
 # Merge-Readiness Checklist
 
 > [!IMPORTANT]
-> **Critical Repository State Notice:** The `main` branch is currently operating under a history-grafting model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `4bad2af8960b748b48591b337994e0a7ffc00d2e` is required for all PRs.**
+> **Critical Repository State Notice:** The `main` branch is currently operating under a history-grafting model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `7ebf40eced6d74803496c99171a669a2533a3389` is required for all PRs.**
 
-Generated on: 2026-08-10 14:27:06 UTC
+Generated on: 2026-08-11 13:26:16 UTC
 
 This checklist identifies top promising PRs for immediate review.
 
@@ -11,21 +11,21 @@ This checklist identifies top promising PRs for immediate review.
 - **Short scope summary**: Medium Risk update implementing 'chore(deps): bump metatrader5 from 5.0.6070 to 5.0.6090' (Candidate for re-validation/review)
 - **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `4bad2af8960b748b48591b337994e0a7ffc00d2e`, tests, docs
+- **Missing items**: Mandatory rebase against commit `7ebf40eced6d74803496c99171a669a2533a3389`, tests, docs
 - **Recommendation**: Needs CI success before merge
 
 ## 2. PR #1786: chore(deps): bump scikit-learn from 1.6.0 to 1.7.2
 - **Short scope summary**: Medium Risk update implementing 'chore(deps): bump scikit-learn from 1.6.0 to 1.7.2' (Candidate for re-validation/review)
 - **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `4bad2af8960b748b48591b337994e0a7ffc00d2e`, tests, docs
+- **Missing items**: Mandatory rebase against commit `7ebf40eced6d74803496c99171a669a2533a3389`, tests, docs
 - **Recommendation**: Needs CI success before merge
 
 ## 3. PR #1784: chore(deps): bump stable-baselines3 from 2.5.0 to 2.9.0
 - **Short scope summary**: Safe Surface update implementing 'chore(deps): bump stable-baselines3 from 2.5.0 to 2.9.0' (Candidate for re-validation/review)
 - **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `4bad2af8960b748b48591b337994e0a7ffc00d2e`
+- **Missing items**: Mandatory rebase against commit `7ebf40eced6d74803496c99171a669a2533a3389`
 - **Recommendation**: Needs CI success before merge
 
 ---

--- a/docs/status/PR_TRIAGE_DAILY.md
+++ b/docs/status/PR_TRIAGE_DAILY.md
@@ -1,6 +1,6 @@
 # Daily PR Triage Dashboard
 
-**Date:** 2026-08-10 14:27:06 UTC
+**Date:** 2026-08-11 13:26:16 UTC
 **Status:** 🔴 HIGH TURBULENCE
 
 ### Turbulence Factors:
@@ -10,7 +10,7 @@
 
 ## 🔝 Top 3 Items That Matter Right Now
 
-1. **Mandatory Rebase:** All open PRs require a mandatory rebase against commit `4bad2af8960b748b48591b337994e0a7ffc00d2e` to ensure compatibility.
+1. **Mandatory Rebase:** All open PRs require a mandatory rebase against commit `7ebf40eced6d74803496c99171a669a2533a3389` to ensure compatibility.
 2. **Address Turbulence:** High number of open PRs (567)
 3. **Re-validate Stale:** Review Safe Surface PR #1784 (chore(deps): bump stable-baselines3 from 2.5.0 to 2.9.0)
 


### PR DESCRIPTION
Updates the daily PR triage dashboard (docs/status/PR_TRIAGE_DAILY.md) and daily merge checklist (docs/status/MERGE_READY_CHECKLIST.md) to reflect the current live state of open PRs, sets the mandatory rebase target to commit 7ebf40eced6d74803496c99171a669a2533a3389, and verifies all triage heuristics and diagnostics test pathways pass cleanly.

---
*PR created automatically by Jules for task [2361972206005679644](https://jules.google.com/task/2361972206005679644) started by @triqbit*