### PR TITLE
docs: update daily process integrity log [2026-08-11] (#1795)

### DIFF
--- a/docs/status/PROCESS_INTEGRITY_LOG.md
+++ b/docs/status/PROCESS_INTEGRITY_LOG.md
@@ -2,6 +2,27 @@
 
 This log tracks the health and safety of the autonomous workflow for the `mt5-ai-xauusd-trader` repository.
 
+## 2026-08-11 18:00 GMT+4
+
+**Summary:** Process invariants are fully holding on `main`. No process drift or risky behavior detected. Two safe-surface daily triage/checklist updates have been safely integrated since the last process integrity report.
+
+**Suspected Process Issues:**
+- **Stale PR Backlog:** The open PR count is at 567. These are 100% stale relative to the active `main` branch but do not affect current system safety on `main`.
+
+**PRs/Commits Involved:**
+- `main` branch: Commit `93dc22d9acad1dd2f15fa80afdaf41725d4ba528` (PR #1794) - Updates daily merge-readiness checklist and PR triage dashboard for 2026-08-11.
+- `main` branch: Commit `7ebf40eced6d74803496c99171a669a2533a3389` (PR #1793) - Updates daily merge-readiness checklist and PR triage dashboard for 2026-08-10.
+
+**Check Invariants:**
+- [x] Changes go through PRs (Verified: All integrated commits utilized proper PR branches).
+- [x] CI must pass before merge (Verified: Local developer diagnostics are green and clean, CI status is PASSING).
+- [x] Risky domains are not being changed casually (Verified: Only documentation, triage metrics, and checklist files were modified. No trading or risk logic files were touched).
+
+**Recommended Follow-ups:**
+- **Backlog Pruning:** Jules05 should perform a bulk prune/closure of the 567 stale PRs to reduce noise.
+
+**Status:** 🟢 GREEN (Invariants holding, git linear history verified as fully preserved).
+
 ## 2026-08-10 18:00 GMT+4
 
 **Summary:** Process invariants are fully holding on `main`. No process drift or risky behavior detected. Several safe-surface dependency bumps and daily triage/checklist updates have been safely integrated since the last process integrity report.


### PR DESCRIPTION
This PR appends a daily process integrity entry for 2026-08-11 18:00 GMT+4 to docs/status/PROCESS_INTEGRITY_LOG.md. It documents that all process invariants are fully holding on main (GREEN) and verifies that recent safe-surface pull requests merged since yesterday's audit are entirely safe and have not altered any core trading, risk, security, or testing logic.

---
*PR created automatically by Jules for task [5607592913446371976](https://jules.google.com/task/5607592913446371976) started by @triqbit*