### PR TITLE
docs: update daily merge-readiness checklist and triage report

### DIFF
--- a/docs/status/MERGE_READY_CHECKLIST.md
+++ b/docs/status/MERGE_READY_CHECKLIST.md
@@ -1,9 +1,9 @@
 # Merge-Readiness Checklist
 
 > [!IMPORTANT]
-> **Critical Repository State Notice:** The `main` branch is currently operating under a history-grafting model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `7ebf40eced6d74803496c99171a669a2533a3389` is required for all PRs.**
+> **Critical Repository State Notice:** The `main` branch is currently operating under a history-grafting model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `035510929da2f085ea59fd638dba90b41e803f7f` is required for all PRs.**
 
-Generated on: 2026-08-11 13:26:16 UTC
+Generated on: 2026-08-11 14:21:03 UTC
 
 This checklist identifies top promising PRs for immediate review.
 
@@ -11,21 +11,21 @@ This checklist identifies top promising PRs for immediate review.
 - **Short scope summary**: Medium Risk update implementing 'chore(deps): bump metatrader5 from 5.0.6070 to 5.0.6090' (Candidate for re-validation/review)
 - **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `7ebf40eced6d74803496c99171a669a2533a3389`, tests, docs
+- **Missing items**: Mandatory rebase against commit `035510929da2f085ea59fd638dba90b41e803f7f`, tests, docs
 - **Recommendation**: Needs CI success before merge
 
 ## 2. PR #1786: chore(deps): bump scikit-learn from 1.6.0 to 1.7.2
 - **Short scope summary**: Medium Risk update implementing 'chore(deps): bump scikit-learn from 1.6.0 to 1.7.2' (Candidate for re-validation/review)
 - **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `7ebf40eced6d74803496c99171a669a2533a3389`, tests, docs
+- **Missing items**: Mandatory rebase against commit `035510929da2f085ea59fd638dba90b41e803f7f`, tests, docs
 - **Recommendation**: Needs CI success before merge
 
 ## 3. PR #1784: chore(deps): bump stable-baselines3 from 2.5.0 to 2.9.0
 - **Short scope summary**: Safe Surface update implementing 'chore(deps): bump stable-baselines3 from 2.5.0 to 2.9.0' (Candidate for re-validation/review)
 - **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `7ebf40eced6d74803496c99171a669a2533a3389`
+- **Missing items**: Mandatory rebase against commit `035510929da2f085ea59fd638dba90b41e803f7f`
 - **Recommendation**: Needs CI success before merge
 
 ---

--- a/docs/status/PR_TRIAGE_DAILY.md
+++ b/docs/status/PR_TRIAGE_DAILY.md
@@ -1,6 +1,6 @@
 # Daily PR Triage Dashboard
 
-**Date:** 2026-08-11 13:26:16 UTC
+**Date:** 2026-08-11 14:21:03 UTC
 **Status:** 🔴 HIGH TURBULENCE
 
 ### Turbulence Factors:
@@ -10,7 +10,7 @@
 
 ## 🔝 Top 3 Items That Matter Right Now
 
-1. **Mandatory Rebase:** All open PRs require a mandatory rebase against commit `7ebf40eced6d74803496c99171a669a2533a3389` to ensure compatibility.
+1. **Mandatory Rebase:** All open PRs require a mandatory rebase against commit `035510929da2f085ea59fd638dba90b41e803f7f` to ensure compatibility.
 2. **Address Turbulence:** High number of open PRs (567)
 3. **Re-validate Stale:** Review Safe Surface PR #1784 (chore(deps): bump stable-baselines3 from 2.5.0 to 2.9.0)
 


### PR DESCRIPTION
This daily contribution updates the repository's merge-readiness checklist and PR triage dashboard for Jules05 and human reviewers to easily audit outstanding pull requests.

What was done:
1. Ran the daily automated triage generator scripts/generate_triage_report.py to regenerate status reports.
2. Verified that docs/status/PR_TRIAGE_DAILY.md and docs/status/MERGE_READY_CHECKLIST.md are correctly formatted.
3. Updated the mandatory rebase target to 035510929da2f085ea59fd638dba90b41e803f7f (the latest commit on main).
4. Ran python -m unittest tests/test_triage_report.py and test_triage_heuristics.py, all of which passed cleanly.

---
*PR created automatically by Jules for task [1199293345915213679](https://jules.google.com/task/1199293345915213679) started by @triqbit*