### PR TITLE
docs: update daily merge-readiness checklist [2026-08-14]

### DIFF
--- a/docs/status/MERGE_READY_CHECKLIST.md
+++ b/docs/status/MERGE_READY_CHECKLIST.md
@@ -3,30 +3,23 @@
 > [!IMPORTANT]
 > **Critical Repository State Notice:** The `main` branch is currently operating under a history-grafting model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `69551eb0208163d5adccccbdb8925bb74b09d1bd` is required for all PRs.**
 
-Generated on: 2026-08-13 13:30:20 UTC
+Generated on: 2026-08-14 17:40:00 UTC
 
 This checklist identifies top promising PRs for immediate review.
 
-## 1. PR #1788: chore(deps): bump metatrader5 from 5.0.6070 to 5.0.6090
-- **Short scope summary**: Medium Risk update implementing 'chore(deps): bump metatrader5 from 5.0.6070 to 5.0.6090' (Candidate for re-validation/review)
-- **Domains touched**: dependencies
+## 1. PR #1784: chore(deps): bump stable-baselines3 from 2.5.0 to 2.9.0
+- **Short scope summary**: Safe Surface dependency update bumping stable-baselines3 package version from 2.5.0 to 2.9.0.
+- **Domains touched**: dependencies (reinforcement learning models / stable-baselines3).
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `69551eb0208163d5adccccbdb8925bb74b09d1bd`, tests, docs
-- **Recommendation**: Needs CI success before merge
+- **Missing items**: Mandatory rebase against commit `69551eb0208163d5adccccbdb8925bb74b09d1bd`.
+- **Recommendation**: Ready for detailed review / testing on local environment before merge once CI succeeds.
 
 ## 2. PR #1786: chore(deps): bump scikit-learn from 1.6.0 to 1.7.2
-- **Short scope summary**: Medium Risk update implementing 'chore(deps): bump scikit-learn from 1.6.0 to 1.7.2' (Candidate for re-validation/review)
-- **Domains touched**: dependencies
+- **Short scope summary**: Medium Risk dependency update bumping scikit-learn package version from 1.6.0 to 1.7.2.
+- **Domains touched**: dependencies (machine learning utilities).
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `69551eb0208163d5adccccbdb8925bb74b09d1bd`, tests, docs
-- **Recommendation**: Needs CI success before merge
-
-## 3. PR #1784: chore(deps): bump stable-baselines3 from 2.5.0 to 2.9.0
-- **Short scope summary**: Safe Surface update implementing 'chore(deps): bump stable-baselines3 from 2.5.0 to 2.9.0' (Candidate for re-validation/review)
-- **Domains touched**: dependencies
-- **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `69551eb0208163d5adccccbdb8925bb74b09d1bd`
-- **Recommendation**: Needs CI success before merge
+- **Missing items**: Mandatory rebase against commit `69551eb0208163d5adccccbdb8925bb74b09d1bd`, compatibility checks for potential api deprecations.
+- **Recommendation**: Candidate for detailed review — requires ensuring scikit-learn APIs remain fully compatible across the codebase.
 
 ---
 *Prepared by Jules06 (qufuwan) for Jules05 and human review.*


### PR DESCRIPTION
This pull request updates the daily merge-readiness checklist (docs/status/MERGE_READY_CHECKLIST.md) for August 14, 2026. It documents the scope, domains touched, CI status, missing items, and recommendations for PR #1784 and PR #1786, complying with all repository guardrails and rebase requirements.

---
*PR created automatically by Jules for task [6541276689592189227](https://jules.google.com/task/6541276689592189227) started by @triqbit*