### PR TITLE
docs: update daily merge-readiness checklist and PR triage [2026-08-14]

### DIFF
--- a/docs/status/MERGE_READY_CHECKLIST.md
+++ b/docs/status/MERGE_READY_CHECKLIST.md
@@ -1,25 +1,32 @@
 # Merge-Readiness Checklist
 
 > [!IMPORTANT]
-> **Critical Repository State Notice:** The `main` branch is currently operating under a history-grafting model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `69551eb0208163d5adccccbdb8925bb74b09d1bd` is required for all PRs.**
+> **Critical Repository State Notice:** The `main` branch is currently operating under a history-grafting model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `d854a930bf46636edeba8e5bc4a00e7c304f453f` is required for all PRs.**
 
-Generated on: 2026-08-14 17:40:00 UTC
+Generated on: 2026-08-14 13:07:22 UTC
 
 This checklist identifies top promising PRs for immediate review.
 
-## 1. PR #1784: chore(deps): bump stable-baselines3 from 2.5.0 to 2.9.0
-- **Short scope summary**: Safe Surface dependency update bumping stable-baselines3 package version from 2.5.0 to 2.9.0.
-- **Domains touched**: dependencies (reinforcement learning models / stable-baselines3).
+## 1. PR #1788: chore(deps): bump metatrader5 from 5.0.6070 to 5.0.6090
+- **Short scope summary**: Medium Risk update implementing 'chore(deps): bump metatrader5 from 5.0.6070 to 5.0.6090' (Candidate for re-validation/review)
+- **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `69551eb0208163d5adccccbdb8925bb74b09d1bd`.
-- **Recommendation**: Ready for detailed review / testing on local environment before merge once CI succeeds.
+- **Missing items**: Mandatory rebase against commit `d854a930bf46636edeba8e5bc4a00e7c304f453f`, tests, docs
+- **Recommendation**: Needs CI success before merge
 
 ## 2. PR #1786: chore(deps): bump scikit-learn from 1.6.0 to 1.7.2
-- **Short scope summary**: Medium Risk dependency update bumping scikit-learn package version from 1.6.0 to 1.7.2.
-- **Domains touched**: dependencies (machine learning utilities).
+- **Short scope summary**: Medium Risk update implementing 'chore(deps): bump scikit-learn from 1.6.0 to 1.7.2' (Candidate for re-validation/review)
+- **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `69551eb0208163d5adccccbdb8925bb74b09d1bd`, compatibility checks for potential api deprecations.
-- **Recommendation**: Candidate for detailed review — requires ensuring scikit-learn APIs remain fully compatible across the codebase.
+- **Missing items**: Mandatory rebase against commit `d854a930bf46636edeba8e5bc4a00e7c304f453f`, tests, docs
+- **Recommendation**: Needs CI success before merge
+
+## 3. PR #1784: chore(deps): bump stable-baselines3 from 2.5.0 to 2.9.0
+- **Short scope summary**: Safe Surface update implementing 'chore(deps): bump stable-baselines3 from 2.5.0 to 2.9.0' (Candidate for re-validation/review)
+- **Domains touched**: dependencies
+- **CI status**: pending
+- **Missing items**: Mandatory rebase against commit `d854a930bf46636edeba8e5bc4a00e7c304f453f`
+- **Recommendation**: Needs CI success before merge
 
 ---
 *Prepared by Jules06 (qufuwan) for Jules05 and human review.*

--- a/docs/status/PR_TRIAGE_DAILY.md
+++ b/docs/status/PR_TRIAGE_DAILY.md
@@ -1,6 +1,6 @@
 # Daily PR Triage Dashboard
 
-**Date:** 2026-08-13 13:30:20 UTC
+**Date:** 2026-08-14 13:07:22 UTC
 **Status:** 🔴 HIGH TURBULENCE
 
 ### Turbulence Factors:
@@ -10,7 +10,7 @@
 
 ## 🔝 Top 3 Items That Matter Right Now
 
-1. **Mandatory Rebase:** All open PRs require a mandatory rebase against commit `69551eb0208163d5adccccbdb8925bb74b09d1bd` to ensure compatibility.
+1. **Mandatory Rebase:** All open PRs require a mandatory rebase against commit `d854a930bf46636edeba8e5bc4a00e7c304f453f` to ensure compatibility.
 2. **Address Turbulence:** High number of open PRs (567)
 3. **Re-validate Stale:** Review Safe Surface PR #1784 (chore(deps): bump stable-baselines3 from 2.5.0 to 2.9.0)
 


### PR DESCRIPTION
Daily intake and risk triage update to documentation files under docs/status. Identifies top promising candidates for review, classifies risk of open PRs under the latest commit rebase target, and maintains process integrity.

---
*PR created automatically by Jules for task [10174774683300175960](https://jules.google.com/task/10174774683300175960) started by @triqbit*