### PR TITLE
chore: improve developer onboarding and runtime doctor experience

### DIFF
--- a/scripts/doctor.py
+++ b/scripts/doctor.py
@@ -654,7 +654,33 @@ def check_contribution_safety():
         return DiagnosticCheck("Contribution Safety", "WARNING", f"Audit failed: {e}")
 
 
+def _reexecute_in_venv_if_available():
+    """Auto-detect repo venv when run with system python and re-execute seamlessly."""
+    # Check if already running in a virtualenv
+    in_venv = hasattr(sys, "real_prefix") or getattr(sys, "base_prefix", sys.prefix) != sys.prefix
+    if in_venv or os.environ.get("_DOCTOR_REEXEC"):
+        return
+
+    root = Path(__file__).resolve().parents[1]
+    venv_python = (
+        root / "venv" / "Scripts" / "python.exe"
+        if sys.platform == "win32"
+        else root / "venv" / "bin" / "python"
+    )
+
+    if venv_python.exists():
+        env = os.environ.copy()
+        env["_DOCTOR_REEXEC"] = "1"
+        try:
+            result = subprocess.run([str(venv_python)] + sys.argv, env=env)
+            sys.exit(result.returncode)
+        except Exception:
+            pass
+
+
 def main():
+    _reexecute_in_venv_if_available()
+
     # Ensure root is in path
     root = Path(__file__).resolve().parents[1]
     sys.path.append(str(root))


### PR DESCRIPTION
1. Problem:
- Running `python3 scripts/doctor.py` directly using system Python when a repository virtualenv exists fails with missing dependencies errors instead of running within the project's virtual environment.

2. Root Cause:
- `scripts/doctor.py` assumed the user manually activated `venv` or invoked `venv/bin/python`, causing setup friction for new developers running `python3 scripts/doctor.py`.

3. Solution:
- Added `_reexecute_in_venv_if_available()` in `scripts/doctor.py` to auto-detect `./venv` and seamlessly re-execute using the virtual environment's Python interpreter with a recursion guard.

4. Impact:
- Developers running `python3 scripts/doctor.py` without explicit virtual environment activation get immediate, accurate system diagnostic checks using project dependencies.

5. Validation:
- Ran `python3 scripts/doctor.py`, `make doctor`, `make demo-synthetic`, and diagnostic unit tests (`tests/test_triage_report.py`, `tests/test_triage_heuristics.py`). All passed cleanly.

6. Safety Check:
- Confirmed no trading, risk, strategy, position sizing, or security logic files were touched.

7. Remaining Gaps:
- None for this runtime doctor onboarding flow.

---
*PR created automatically by Jules for task [17708813726407829978](https://jules.google.com/task/17708813726407829978) started by @triqbit*