### PR TITLE
docs: update daily merge-readiness checklist and PR triage [2026-08-15]

### DIFF
--- a/docs/status/MERGE_READY_CHECKLIST.md
+++ b/docs/status/MERGE_READY_CHECKLIST.md
@@ -1,9 +1,9 @@
 # Merge-Readiness Checklist
 
 > [!IMPORTANT]
-> **Critical Repository State Notice:** The `main` branch is currently operating under a history-grafting model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `d86cf709bf9104b7ff1781a0204fae981596468f` is required for all PRs.**
+> **Critical Repository State Notice:** The `main` branch is currently operating under a history-grafting model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `5da20dce2f502037c99dc7dffba79503fc8589e5` is required for all PRs.**
 
-Generated on: 2026-08-14 14:28:44 UTC
+Generated on: 2026-08-15 13:07:39 UTC
 
 This checklist identifies top promising PRs for immediate review.
 
@@ -11,21 +11,21 @@ This checklist identifies top promising PRs for immediate review.
 - **Short scope summary**: Medium Risk update implementing 'chore(deps): bump metatrader5 from 5.0.6070 to 5.0.6090' (Candidate for re-validation/review)
 - **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `d86cf709bf9104b7ff1781a0204fae981596468f`, tests, docs
+- **Missing items**: Mandatory rebase against commit `5da20dce2f502037c99dc7dffba79503fc8589e5`, tests, docs
 - **Recommendation**: Needs CI success before merge
 
 ## 2. PR #1786: chore(deps): bump scikit-learn from 1.6.0 to 1.7.2
 - **Short scope summary**: Medium Risk update implementing 'chore(deps): bump scikit-learn from 1.6.0 to 1.7.2' (Candidate for re-validation/review)
 - **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `d86cf709bf9104b7ff1781a0204fae981596468f`, tests, docs
+- **Missing items**: Mandatory rebase against commit `5da20dce2f502037c99dc7dffba79503fc8589e5`, tests, docs
 - **Recommendation**: Needs CI success before merge
 
 ## 3. PR #1784: chore(deps): bump stable-baselines3 from 2.5.0 to 2.9.0
 - **Short scope summary**: Safe Surface update implementing 'chore(deps): bump stable-baselines3 from 2.5.0 to 2.9.0' (Candidate for re-validation/review)
 - **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `d86cf709bf9104b7ff1781a0204fae981596468f`
+- **Missing items**: Mandatory rebase against commit `5da20dce2f502037c99dc7dffba79503fc8589e5`
 - **Recommendation**: Needs CI success before merge
 
 ---

--- a/docs/status/PR_TRIAGE_DAILY.md
+++ b/docs/status/PR_TRIAGE_DAILY.md
@@ -1,6 +1,6 @@
 # Daily PR Triage Dashboard
 
-**Date:** 2026-08-14 14:28:44 UTC
+**Date:** 2026-08-15 13:07:39 UTC
 **Status:** 🔴 HIGH TURBULENCE
 
 ### Turbulence Factors:
@@ -10,7 +10,7 @@
 
 ## 🔝 Top 3 Items That Matter Right Now
 
-1. **Mandatory Rebase:** All open PRs require a mandatory rebase against commit `d86cf709bf9104b7ff1781a0204fae981596468f` to ensure compatibility.
+1. **Mandatory Rebase:** All open PRs require a mandatory rebase against commit `5da20dce2f502037c99dc7dffba79503fc8589e5` to ensure compatibility.
 2. **Address Turbulence:** High number of open PRs (567)
 3. **Re-validate Stale:** Review Safe Surface PR #1784 (chore(deps): bump stable-baselines3 from 2.5.0 to 2.9.0)
 


### PR DESCRIPTION
Updates the daily PR triage dashboard (`docs/status/PR_TRIAGE_DAILY.md`) and daily merge-readiness checklist (`docs/status/MERGE_READY_CHECKLIST.md`) for August 15, 2026. Updates latest commit reference target to `5da20dce2f502037c99dc7dffba79503fc8589e5` and classifies open PR risks and candidates for review today.

---
*PR created automatically by Jules for task [222657699117993167](https://jules.google.com/task/222657699117993167) started by @triqbit*