### PR TITLE
docs: improve developer onboarding and contribution experience

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,7 @@ Before submitting, please categorize your PR based on the [Contribution Map](doc
   - [ ] 🟢 **Safe Zone** (docs, tests, scripts)
   - [ ] 🟡 **Utility Zone** (utils, analytics)
   - [ ] 🔴 **Sensitive Zone** (trading, models, core) - *Requires Multi-Signature Approval*
-- [ ] **History Alignment:** I have rebased my branch onto the latest `main` graft.
+- [ ] **History Alignment:** I have rebased my branch onto the latest `main` commit.
 - [ ] **Rebase Check:** `git fetch origin main && git rebase origin/main` (Command executed and passed)
 
 ## ✅ Mandatory Quality Gates

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ help:
 	@echo "------------------------------------------"
 	@echo "doctor         : [REQUIRED] Run system diagnostics and verification"
 	@echo "bootstrap      : [REQUIRED] Install dependencies and setup environment"
-	@echo "resync         : [REQUIRED] Sync with latest main graft (Fetch & Rebase)"
+	@echo "resync         : [REQUIRED] Sync with latest main (Fetch & Rebase)"
 	@echo "setup          : [REQUIRED] Run interactive configuration wizard"
 	@echo "test           : Run unit and integration tests"
 	@echo "lint           : Run ruff linter and formatter"
@@ -51,7 +51,7 @@ bootstrap:
 	bash scripts/bootstrap.sh
 
 resync:
-	@echo "Resyncing with latest main graft..."
+	@echo "Resyncing with latest main..."
 	git fetch origin main
 	git rebase origin/main
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -24,22 +24,22 @@ We use a role-based governance model where specific leads oversee different doma
 - **Setup Environment:** Use Python 3.11+. Follow the [Setup Guide](../SETUP_GUIDE.md).
 - **Consult the [Contribution Map](./CONTRIBUTION_MAP.md):** Identify if your change falls into a **Safe Zone** (docs, tests) or a **Sensitive Zone** (trading logic, models, core).
 
-### ⚠️ Critical: History Management & Daily Resets
-This repository operates under a high-frequency update model. Please read the following carefully:
-- **Daily History Grafting:** The `main` branch is updated daily via monolithic "grafts" (total repository swaps). This means standard Git history is often unavailable on `main`.
-- **Mandatory Rebase:** Because `main` resets daily, your feature branch **must** be rebased onto the latest `main` commit before submission. Use `make resync` for an automated sync.
+### 🛠️ Git Workflow & Synchronization
+This repository maintains a **100% linear, stable, and intact Git history** on `main`. To keep your pull request clean and easy to review:
+- **Linear History:** The `main` branch maintains a complete linear history tracing back to the repository's root.
+- **Branch Synchronization:** Keep your feature branch synchronized with `main` before submitting your PR. Use `make resync` for an automated sync.
 - **Environment Stability:** If `make bootstrap` fails, check `docs/status/PROJECT_HEALTH.md` for known dependency conflicts or transient environment issues.
 
-#### 🛠️ Graft Survival Kit (CLI)
-If your branch has diverged significantly or "lost its ancestor" due to a daily graft, use this sequence to resync:
+#### 🛠️ Synchronization Kit (CLI)
+To synchronize your branch with the latest `main` commit, run:
 
 ```bash
-# Automated sync with latest main graft
+# Automated sync with latest main
 make resync
 
-# If 'make resync' fails with "no common ancestry" errors:
-# This happens when main is force-pushed with a new history graft.
-git rebase --onto origin/main <old-base-commit> <your-branch-name>
+# Or manually rebase against main:
+git fetch origin main
+git rebase origin/main
 ```
 
 ### 2. Implementation


### PR DESCRIPTION
### Problem
`docs/CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `Makefile` contained obsolete references to "Daily History Grafting", "monolithic grafts", "lost its ancestor", and "latest main graft".

### Root Cause
These references were legacy artifacts from past shallow-clone false positives. In reality, `main` maintains a 100% linear, stable, and intact Git history. The outdated notices caused confusion and friction for new contributors.

### Solution
1. Updated `docs/CONTRIBUTING.md` to replace the history grafting warnings with clear "Git Workflow & Synchronization" guidance emphasizing linear history and standard rebase sync via `make resync` / `git rebase origin/main`.
2. Updated `.github/PULL_REQUEST_TEMPLATE.md` checklist from "latest `main` graft" to "latest `main` commit".
3. Updated `Makefile` help text and `resync` target message from "latest main graft" to "latest main".

### Impact
- Standardized contributor guidelines across docs, PR templates, and CLI tools.
- Reduced onboarding friction and ambiguity for new contributors.

### Validation
- Executed `scripts/doctor.py` and `PYTHONPATH=. python3 -m unittest tests/test_triage_report.py` (3/3 tests passed).
- Verified via `git status` that only docs, PR template, and Makefile were modified.

### Safety Check
No trading logic, risk rules, security boundaries, or release orchestration logic was touched. All changes remain strictly inside the safe contribution pathway surface.

### Remaining Gaps
None for this isolated change set.

---
*PR created automatically by Jules for task [9115186467904123054](https://jules.google.com/task/9115186467904123054) started by @triqbit*