### PR TITLE
docs: update daily process integrity log [2026-08-17]

### DIFF
--- a/docs/status/PROCESS_INTEGRITY_LOG.md
+++ b/docs/status/PROCESS_INTEGRITY_LOG.md
@@ -2,6 +2,26 @@
 
 This log tracks the health and safety of the autonomous workflow for the `mt5-ai-xauusd-trader` repository.
 
+## 2026-08-17 18:00 GMT+4
+
+**Summary:** Process invariants are fully holding on `main`. No process drift or risky behavior detected. One safe-surface daily PR triage and merge-readiness checklist update pull request has been integrated since the last process integrity report.
+
+**Suspected Process Issues:**
+- **Stale PR Backlog:** The open PR count remains at 567. These are 100% stale relative to the active `main` branch but do not affect current system safety on `main`.
+
+**PRs/Commits Involved:**
+- `main` branch: Commit `fe8b22c` (PR #1823) - Updates daily PR triage dashboard and merge-readiness checklist for 2026-08-17.
+
+**Check Invariants:**
+- [x] Changes go through PRs (Verified: Integrated commit utilized proper PR branch).
+- [x] CI must pass before merge (Verified: Local developer diagnostics and heuristics tests pass cleanly, CI status is PASSING).
+- [x] Risky domains are not being changed casually (Verified: Only documentation, triage metrics, and checklist files were modified. No trading or risk logic files were touched).
+
+**Recommended Follow-ups:**
+- **Backlog Pruning:** Jules05 should perform a bulk prune/closure of the 567 stale PRs to reduce noise.
+
+**Status:** 🟢 GREEN (Invariants holding, git linear history verified as fully preserved).
+
 ## 2026-08-16 18:00 GMT+4
 
 **Summary:** Process invariants are fully holding on `main`. No process drift or risky behavior detected. One safe-surface daily PR triage and merge-readiness checklist update pull request has been integrated since the last process integrity report.


### PR DESCRIPTION
Daily Process Integrity & Drift Watcher report for 2026-08-17 18:00 GMT+4. Documented that process invariants are holding on `main` (🟢 GREEN) following commit fe8b22c (PR #1823), with verified linear history and clean diagnostic test execution.

---
*PR created automatically by Jules for task [3828210956530942435](https://jules.google.com/task/3828210956530942435) started by @triqbit*