### PR TITLE
docs: update daily merge-readiness checklist and PR triage dashboard [2026-08-19]

### DIFF
--- a/docs/status/MERGE_READY_CHECKLIST.md
+++ b/docs/status/MERGE_READY_CHECKLIST.md
@@ -1,9 +1,9 @@
 # Merge-Readiness Checklist
 
 > [!IMPORTANT]
-> **Critical Repository State Notice:** The `main` branch is currently operating under a linear git history model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `b9dcc0dd2044824a6479a93e02a0f8a3cbc8dde0` is required for all PRs.**
+> **Critical Repository State Notice:** The `main` branch is currently operating under a linear git history model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `e2439fa558738ceed4b1332ba4d099e2644d1e72` is required for all PRs.**
 
-Generated on: 2026-08-18 14:25:13 UTC
+Generated on: 2026-08-19 13:10:48 UTC
 
 This checklist identifies top promising PRs for immediate review.
 
@@ -11,21 +11,21 @@ This checklist identifies top promising PRs for immediate review.
 - **Short scope summary**: Safe Surface update implementing 'chore(deps): bump pydantic-settings from 2.14.2 to 2.15.0' (Candidate for re-validation/review)
 - **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `b9dcc0dd2044824a6479a93e02a0f8a3cbc8dde0`
+- **Missing items**: Mandatory rebase against commit `e2439fa558738ceed4b1332ba4d099e2644d1e72`
 - **Recommendation**: Needs CI success before merge
 
 ## 2. PR #1788: chore(deps): bump metatrader5 from 5.0.6070 to 5.0.6090
 - **Short scope summary**: Medium Risk update implementing 'chore(deps): bump metatrader5 from 5.0.6070 to 5.0.6090' (Candidate for re-validation/review)
 - **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `b9dcc0dd2044824a6479a93e02a0f8a3cbc8dde0`, tests, docs
+- **Missing items**: Mandatory rebase against commit `e2439fa558738ceed4b1332ba4d099e2644d1e72`, tests, docs
 - **Recommendation**: Needs CI success before merge
 
 ## 3. PR #1782: chore(deps): bump python-socketio from 4.6.1 to 5.16.4
 - **Short scope summary**: Medium Risk update implementing 'chore(deps): bump python-socketio from 4.6.1 to 5.16.4' (Candidate for re-validation/review)
 - **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `b9dcc0dd2044824a6479a93e02a0f8a3cbc8dde0`, tests, docs
+- **Missing items**: Mandatory rebase against commit `e2439fa558738ceed4b1332ba4d099e2644d1e72`, tests, docs
 - **Recommendation**: Needs CI success before merge
 
 ---

--- a/docs/status/PR_TRIAGE_DAILY.md
+++ b/docs/status/PR_TRIAGE_DAILY.md
@@ -1,6 +1,6 @@
 # Daily PR Triage Dashboard
 
-**Date:** 2026-08-18 14:25:13 UTC
+**Date:** 2026-08-19 13:10:48 UTC
 **Status:** 🔴 HIGH TURBULENCE
 
 ### Turbulence Factors:
@@ -10,7 +10,7 @@
 
 ## 🔝 Top 3 Items That Matter Right Now
 
-1. **Mandatory Rebase:** All open PRs require a mandatory rebase against commit `b9dcc0dd2044824a6479a93e02a0f8a3cbc8dde0` to ensure compatibility.
+1. **Mandatory Rebase:** All open PRs require a mandatory rebase against commit `e2439fa558738ceed4b1332ba4d099e2644d1e72` to ensure compatibility.
 2. **Address Turbulence:** High number of open PRs (565)
 3. **Re-validate Stale:** Review Safe Surface PR #1820 (chore(deps): bump pydantic-settings from 2.14.2 to 2.15.0)
 


### PR DESCRIPTION
Problem: Daily PR triage dashboard and merge-readiness checklist require updating for reviewers and Jules05.
Root Cause: Daily scheduled workflow routine.
Solution: Executed `scripts/generate_triage_report.py` to refresh `docs/status/PR_TRIAGE_DAILY.md` and `docs/status/MERGE_READY_CHECKLIST.md` with mandatory rebase SHA `e2439fa558738ceed4b1332ba4d099e2644d1e72`.
Impact: Provides clear PR risk classification, CI statuses, and 2-4 candidate PRs for review.
Validation: Verified structure with `/home/jules/self_created_tools/verify_triage_outputs.py` and executed unit tests `python3 -m unittest tests/test_triage_report.py tests/test_triage_heuristics.py`.
Safety Check: Safe surface documentation updates only; no trading, risk, or security logic modified.

---
*PR created automatically by Jules for task [6293284052868244306](https://jules.google.com/task/6293284052868244306) started by @triqbit*