### PR TITLE
docs: update daily process integrity log [2026-08-22]

### DIFF
--- a/docs/status/PROCESS_INTEGRITY_LOG.md
+++ b/docs/status/PROCESS_INTEGRITY_LOG.md
@@ -2,6 +2,29 @@
 
 This log tracks the health and safety of the autonomous workflow for the `mt5-ai-xauusd-trader` repository.
 
+## 2026-08-22 18:00 GMT+4
+
+**Summary:** Process invariants are fully holding on `main`. No process drift or risky behavior detected. Four safe-surface documentation, triage dashboard, audit evidence harmonization, and contribution pathway pull requests have been integrated since the last process integrity report.
+
+**Suspected Process Issues:**
+- **Stale PR Backlog:** The open PR count remains at 565. These are 100% stale relative to the active `main` branch but do not affect current system safety on `main`.
+
+**PRs/Commits Involved:**
+- `main` branch: Commit `373d646` (PR #1838) - Updates FIRST_REAL_CONTRIBUTION.md to reflect linear git history.
+- `main` branch: Commit `75fb73d` (PR #1837) - Updates daily PR triage and merge-readiness checklist [2026-08-22].
+- `main` branch: Commit `2b897da` (PR #1836) - Harmonizes git history alignment in audit evidence reports across docs/audits/.
+- `main` branch: Commit `26135d2` / `684b825` (PR #1835) - Updates daily merge-ready checklist, triage report, and daily process integrity log [2026-08-21].
+
+**Check Invariants:**
+- [x] Changes go through PRs (Verified: All integrated commits utilized proper PR branches).
+- [x] CI must pass before merge (Verified: Local developer diagnostics and heuristics tests pass cleanly, CI status is PASSING).
+- [x] Risky domains are not being changed casually (Verified: Only documentation, audit evidence reports, triage metrics, and checklist files were modified. No trading or risk logic files were touched).
+
+**Recommended Follow-ups:**
+- **Backlog Pruning:** Jules05 should perform a bulk prune/closure of the 565 stale PRs to reduce noise.
+
+**Status:** 🟢 GREEN (Invariants holding, git linear history verified as fully preserved).
+
 ## 2026-08-21 18:00 GMT+4
 
 **Summary:** Process invariants are fully holding on `main`. No process drift or risky behavior detected. One safe-surface daily PR triage and merge-readiness checklist update pull request has been integrated since the last process integrity report.


### PR DESCRIPTION
Appends the daily Process Integrity & Drift Watcher report entry for 2026-08-22 18:00 GMT+4 to `docs/status/PROCESS_INTEGRITY_LOG.md`. Documents that process invariants are fully holding on `main` (🟢 GREEN) following PRs #1835, #1836, #1837, and #1838. All diagnostic unit tests pass cleanly.

---
*PR created automatically by Jules for task [12641057037705556137](https://jules.google.com/task/12641057037705556137) started by @triqbit*