### PR TITLE
docs: update daily PR triage dashboard [2026-08-23]

### DIFF
--- a/docs/status/MERGE_READY_CHECKLIST.md
+++ b/docs/status/MERGE_READY_CHECKLIST.md
@@ -1,9 +1,9 @@
 # Merge-Readiness Checklist
 
 > [!IMPORTANT]
-> **Critical Repository State Notice:** The `main` branch is currently operating under a linear git history model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `07b31a613697738e65fef0d606d6cfc295fde724` is required for all PRs.**
+> **Critical Repository State Notice:** The `main` branch is currently operating under a linear git history model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `d004f93da5beef83896ee60026544b87e3933f18` is required for all PRs.**
 
-Generated on: 2026-08-22 14:24:20 UTC
+Generated on: 2026-08-23 13:10:36 UTC
 
 This checklist identifies top promising PRs for immediate review.
 
@@ -11,21 +11,21 @@ This checklist identifies top promising PRs for immediate review.
 - **Short scope summary**: Safe Surface update implementing 'chore(deps): bump pydantic-settings from 2.14.2 to 2.15.0' (Candidate for re-validation/review)
 - **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `07b31a613697738e65fef0d606d6cfc295fde724`
+- **Missing items**: Mandatory rebase against commit `d004f93da5beef83896ee60026544b87e3933f18`
 - **Recommendation**: Needs CI success before merge
 
 ## 2. PR #1788: chore(deps): bump metatrader5 from 5.0.6070 to 5.0.6090
 - **Short scope summary**: Medium Risk update implementing 'chore(deps): bump metatrader5 from 5.0.6070 to 5.0.6090' (Candidate for re-validation/review)
 - **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `07b31a613697738e65fef0d606d6cfc295fde724`, tests, docs
+- **Missing items**: Mandatory rebase against commit `d004f93da5beef83896ee60026544b87e3933f18`, tests, docs
 - **Recommendation**: Needs CI success before merge
 
 ## 3. PR #1782: chore(deps): bump python-socketio from 4.6.1 to 5.16.4
 - **Short scope summary**: Medium Risk update implementing 'chore(deps): bump python-socketio from 4.6.1 to 5.16.4' (Candidate for re-validation/review)
 - **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `07b31a613697738e65fef0d606d6cfc295fde724`, tests, docs
+- **Missing items**: Mandatory rebase against commit `d004f93da5beef83896ee60026544b87e3933f18`, tests, docs
 - **Recommendation**: Needs CI success before merge
 
 ---

--- a/docs/status/PR_TRIAGE_DAILY.md
+++ b/docs/status/PR_TRIAGE_DAILY.md
@@ -1,6 +1,6 @@
 # Daily PR Triage Dashboard
 
-**Date:** 2026-08-22 14:24:20 UTC
+**Date:** 2026-08-23 13:10:36 UTC
 **Status:** 🔴 HIGH TURBULENCE
 
 ### Turbulence Factors:
@@ -10,7 +10,7 @@
 
 ## 🔝 Top 3 Items That Matter Right Now
 
-1. **Mandatory Rebase:** All open PRs require a mandatory rebase against commit `07b31a613697738e65fef0d606d6cfc295fde724` to ensure compatibility.
+1. **Mandatory Rebase:** All open PRs require a mandatory rebase against commit `d004f93da5beef83896ee60026544b87e3933f18` to ensure compatibility.
 2. **Address Turbulence:** High number of open PRs (565)
 3. **Re-validate Stale:** Review Safe Surface PR #1820 (chore(deps): bump pydantic-settings from 2.14.2 to 2.15.0)
 


### PR DESCRIPTION
Executed the daily PR intake and risk triage dashboard routine. Updated `docs/status/PR_TRIAGE_DAILY.md` and `docs/status/MERGE_READY_CHECKLIST.md` with timestamp `2026-08-23 13:10:36 UTC` and mandatory rebase target SHA `d004f93da5beef83896ee60026544b87e3933f18`. Verified unit tests in `tests/test_triage_report.py` and `tests/test_triage_heuristics.py`.

---
*PR created automatically by Jules for task [11181404814917507011](https://jules.google.com/task/11181404814917507011) started by @triqbit*