### PR TITLE
docs: update daily process integrity log [2026-08-23]

### DIFF
--- a/docs/status/PROCESS_INTEGRITY_LOG.md
+++ b/docs/status/PROCESS_INTEGRITY_LOG.md
@@ -2,6 +2,26 @@
 
 This log tracks the health and safety of the autonomous workflow for the `mt5-ai-xauusd-trader` repository.
 
+## 2026-08-23 18:00 GMT+4
+
+**Summary:** Process invariants are fully holding on `main`. No process drift or risky behavior detected. One safe-surface daily PR triage and merge-readiness checklist update pull request has been integrated since the last process integrity report.
+
+**Suspected Process Issues:**
+- **Stale PR Backlog:** The open PR count remains at 565. These are 100% stale relative to the active `main` branch but do not affect current system safety on `main`.
+
+**PRs/Commits Involved:**
+- `main` branch: Commit `ae75b89` (PR #1841) - Updates daily PR triage dashboard and merge-readiness checklist for 2026-08-23.
+
+**Check Invariants:**
+- [x] Changes go through PRs (Verified: Integrated commit utilized proper PR branch).
+- [x] CI must pass before merge (Verified: Local developer diagnostics and heuristics tests pass cleanly, CI status is PASSING).
+- [x] Risky domains are not being changed casually (Verified: Only documentation, triage metrics, and checklist files were modified. No trading or risk logic files were touched).
+
+**Recommended Follow-ups:**
+- **Backlog Pruning:** Jules05 should perform a bulk prune/closure of the 565 stale PRs to reduce noise.
+
+**Status:** 🟢 GREEN (Invariants holding, git linear history verified as fully preserved).
+
 ## 2026-08-22 18:00 GMT+4
 
 **Summary:** Process invariants are fully holding on `main`. No process drift or risky behavior detected. Four safe-surface documentation, triage dashboard, audit evidence harmonization, and contribution pathway pull requests have been integrated since the last process integrity report.


### PR DESCRIPTION
Appends the daily process integrity report for 2026-08-23 to docs/status/PROCESS_INTEGRITY_LOG.md documenting that process invariants are fully holding on main (🟢 GREEN).

---
*PR created automatically by Jules for task [572286106262419803](https://jules.google.com/task/572286106262419803) started by @triqbit*