### PR TITLE
docs: update daily PR triage dashboard and merge checklist [2026-08-26]

### DIFF
--- a/docs/status/MERGE_READY_CHECKLIST.md
+++ b/docs/status/MERGE_READY_CHECKLIST.md
@@ -1,9 +1,9 @@
 # Merge-Readiness Checklist
 
 > [!IMPORTANT]
-> **Critical Repository State Notice:** The `main` branch is currently operating under a linear git history model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `eb8f8686736fbcbb433e50a7552a8822e30a431b` is required for all PRs.**
+> **Critical Repository State Notice:** The `main` branch is currently operating under a linear git history model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `7be545bfbefd8c52d30198c9279160750e99ce48` is required for all PRs.**
 
-Generated on: 2026-08-25 14:18:43 UTC
+Generated on: 2026-08-26 13:29:01 UTC
 
 This checklist identifies top promising PRs for immediate review.
 
@@ -11,21 +11,21 @@ This checklist identifies top promising PRs for immediate review.
 - **Short scope summary**: Medium Risk update implementing 'chore(deps): bump metatrader5 from 5.0.6070 to 5.0.6090' (Candidate for re-validation/review)
 - **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `eb8f8686736fbcbb433e50a7552a8822e30a431b`, tests, docs
+- **Missing items**: Mandatory rebase against commit `7be545bfbefd8c52d30198c9279160750e99ce48`, tests, docs
 - **Recommendation**: Needs CI success before merge
 
 ## 2. PR #1697: docs: update process integrity log [2026-07-21]
 - **Short scope summary**: Safe Surface update implementing 'docs: update process integrity log [2026-07-21]' (Candidate for re-validation/review)
 - **Domains touched**: docs
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `eb8f8686736fbcbb433e50a7552a8822e30a431b`
+- **Missing items**: Mandatory rebase against commit `7be545bfbefd8c52d30198c9279160750e99ce48`
 - **Recommendation**: Needs CI success before merge
 
 ## 3. PR #1661: DX: update process integrity log and project health [2026-07-14]
 - **Short scope summary**: Safe Surface update implementing 'DX: update process integrity log and project health [2026-07-14]' (Candidate for re-validation/review)
 - **Domains touched**: docs
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `eb8f8686736fbcbb433e50a7552a8822e30a431b`
+- **Missing items**: Mandatory rebase against commit `7be545bfbefd8c52d30198c9279160750e99ce48`
 - **Recommendation**: Needs CI success before merge
 
 ---

--- a/docs/status/PR_TRIAGE_DAILY.md
+++ b/docs/status/PR_TRIAGE_DAILY.md
@@ -1,6 +1,6 @@
 # Daily PR Triage Dashboard
 
-**Date:** 2026-08-25 13:08:53 UTC
+**Date:** 2026-08-26 13:29:01 UTC
 **Status:** 🔴 HIGH TURBULENCE
 
 ### Turbulence Factors:
@@ -10,7 +10,7 @@
 
 ## 🔝 Top 3 Items That Matter Right Now
 
-1. **Mandatory Rebase:** All open PRs require a mandatory rebase against commit `bd96f31eb9288ef166c9d0fc1f134b2567cfaec4` to ensure compatibility.
+1. **Mandatory Rebase:** All open PRs require a mandatory rebase against commit `7be545bfbefd8c52d30198c9279160750e99ce48` to ensure compatibility.
 2. **Address Turbulence:** High number of open PRs (563)
 3. **Re-validate Stale:** Review Safe Surface PR #1740 (docs: update daily merge-readiness checklist and PR triage [2026-07-31])
 


### PR DESCRIPTION
Executed the daily PR intake and risk triage dashboard routine. Updated docs/status/PR_TRIAGE_DAILY.md and docs/status/MERGE_READY_CHECKLIST.md with mandatory rebase target commit SHA 7be545bfbefd8c52d30198c9279160750e99ce48. Verified unit tests in tests/test_triage_report.py and tests/test_triage_heuristics.py pass cleanly.

---
*PR created automatically by Jules for task [6545361865773945597](https://jules.google.com/task/6545361865773945597) started by @triqbit*