### PR TITLE
docs: update daily PR triage dashboard [2026-08-27]

### DIFF
--- a/docs/status/MERGE_READY_CHECKLIST.md
+++ b/docs/status/MERGE_READY_CHECKLIST.md
@@ -1,9 +1,9 @@
 # Merge-Readiness Checklist
 
 > [!IMPORTANT]
-> **Critical Repository State Notice:** The `main` branch is currently operating under a linear git history model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `12236c5efd152b2b90ab2ddfeef1893c18d15752` is required for all PRs.**
+> **Critical Repository State Notice:** The `main` branch is currently operating under a linear git history model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `22ab44adefac41ccdd26ca060d9ed7a9f44185f1` is required for all PRs.**
 
-Generated on: 2026-08-26 14:10:07 UTC
+Generated on: 2026-08-27 13:24:06 UTC
 
 This checklist identifies top promising PRs for immediate review.
 
@@ -11,21 +11,21 @@ This checklist identifies top promising PRs for immediate review.
 - **Short scope summary**: Medium Risk update implementing 'chore(deps): bump metatrader5 from 5.0.6070 to 5.0.6090' (Candidate for re-validation/review)
 - **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `12236c5efd152b2b90ab2ddfeef1893c18d15752`, tests, docs
+- **Missing items**: Mandatory rebase against commit `22ab44adefac41ccdd26ca060d9ed7a9f44185f1`, tests, docs
 - **Recommendation**: Needs CI success before merge
 
 ## 2. PR #1697: docs: update process integrity log [2026-07-21]
 - **Short scope summary**: Safe Surface update implementing 'docs: update process integrity log [2026-07-21]' (Candidate for re-validation/review)
 - **Domains touched**: docs
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `12236c5efd152b2b90ab2ddfeef1893c18d15752`
+- **Missing items**: Mandatory rebase against commit `22ab44adefac41ccdd26ca060d9ed7a9f44185f1`
 - **Recommendation**: Needs CI success before merge
 
 ## 3. PR #1661: DX: update process integrity log and project health [2026-07-14]
 - **Short scope summary**: Safe Surface update implementing 'DX: update process integrity log and project health [2026-07-14]' (Candidate for re-validation/review)
 - **Domains touched**: docs
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `12236c5efd152b2b90ab2ddfeef1893c18d15752`
+- **Missing items**: Mandatory rebase against commit `22ab44adefac41ccdd26ca060d9ed7a9f44185f1`
 - **Recommendation**: Needs CI success before merge
 
 ---

--- a/docs/status/PR_TRIAGE_DAILY.md
+++ b/docs/status/PR_TRIAGE_DAILY.md
@@ -1,6 +1,6 @@
 # Daily PR Triage Dashboard
 
-**Date:** 2026-08-26 13:29:01 UTC
+**Date:** 2026-08-27 13:24:06 UTC
 **Status:** 🔴 HIGH TURBULENCE
 
 ### Turbulence Factors:
@@ -10,7 +10,7 @@
 
 ## 🔝 Top 3 Items That Matter Right Now
 
-1. **Mandatory Rebase:** All open PRs require a mandatory rebase against commit `7be545bfbefd8c52d30198c9279160750e99ce48` to ensure compatibility.
+1. **Mandatory Rebase:** All open PRs require a mandatory rebase against commit `22ab44adefac41ccdd26ca060d9ed7a9f44185f1` to ensure compatibility.
 2. **Address Turbulence:** High number of open PRs (563)
 3. **Re-validate Stale:** Review Safe Surface PR #1740 (docs: update daily merge-readiness checklist and PR triage [2026-07-31])
 


### PR DESCRIPTION
Updates docs/status/PR_TRIAGE_DAILY.md and docs/status/MERGE_READY_CHECKLIST.md with daily open PR triage summary, risk classifications, candidate recommendations, and updated rebase target commit SHA.

---
*PR created automatically by Jules for task [14293568323699772343](https://jules.google.com/task/14293568323699772343) started by @triqbit*