### PR TITLE
chore: re-pin python-socketio to 4.6.1 to fix bootstrap dependency conflict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "python-telegram-bot==22.8",
     "psutil==7.2.2",
     "optuna==4.9.0",
-    "python-socketio==5.16.4",
+    "python-socketio==4.6.1",
     "MetaTrader5==5.0.6070; sys_platform == 'win32'",
     "metaapi-cloud-sdk==29.1.1",
 ]

--- a/requirements-ci-no-talib.txt
+++ b/requirements-ci-no-talib.txt
@@ -22,7 +22,7 @@ pydantic-settings==2.15.0
 metaapi-cloud-sdk==29.1.1
 
 # -- Testing -------------------------------------------------------
-python-socketio==5.16.4
+python-socketio==4.6.1
 optuna==4.9.0
 pytest==9.1.1
 pytest-asyncio==1.4.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -25,7 +25,7 @@ pydantic-settings==2.15.0
 metaapi-cloud-sdk==29.1.1
 
 # -- Testing -------------------------------------------------------
-python-socketio==5.16.4
+python-socketio==4.6.1
 optuna==4.9.0
 pytest==9.1.1
 pytest-asyncio==1.4.0

--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -48,7 +48,7 @@ pydantic-settings==2.15.0
 tomli==2.4.1
 
 # -- Utilities -----------------------------------------------
-python-socketio==5.16.4
+python-socketio==4.6.1
 python-dateutil==2.9.0.post0
 nest-asyncio==1.6.0
 pytz==2026.3.post1

--- a/requirements-linux.txt
+++ b/requirements-linux.txt
@@ -61,7 +61,7 @@ ruff==0.16.4
 mypy==2.3.1
 
 # ── Utilities ───────────────────────────────────────────────
-python-socketio==5.16.4
+python-socketio==4.6.1
 python-dateutil==2.9.0.post0
 pytz==2026.3.post1
 click==8.4.2

--- a/requirements-temp.txt
+++ b/requirements-temp.txt
@@ -60,7 +60,7 @@ ruff==0.16.4
 mypy==2.3.1
 
 # ── Utilities ───────────────────────────────────────────────
-python-socketio==5.16.4
+python-socketio==4.6.1
 python-dateutil==2.9.0.post0
 pytz==2026.3.post1
 click==8.4.2

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -24,7 +24,7 @@ pydantic-settings==2.15.0
 metaapi-cloud-sdk==29.1.1
 
 # -- Testing -------------------------------------------------------
-python-socketio==5.16.4
+python-socketio==4.6.1
 optuna==4.9.0
 pytest==9.1.1
 pytest-asyncio==1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,7 +63,7 @@ ruff==0.16.4
 mypy==2.3.1
 
 # ── Utilities ───────────────────────────────────────────────
-python-socketio==5.16.4
+python-socketio==4.6.1
 python-dateutil==2.9.0.post0
 nest-asyncio==1.6.0
 pytz==2026.3.post1


### PR DESCRIPTION
Re-pin `python-socketio` to `4.6.1` across `pyproject.toml` and all 7 `requirements*.txt` files to eliminate the `metaapi-cloud-sdk` dependency resolution conflict and restore first-run `make bootstrap` and `make doctor` execution.

### Problem
New developer onboarding via `make bootstrap` previously failed with a `ResolutionImpossible` error due to `metaapi-cloud-sdk==29.1.1` requiring `python-socketio <5.0.0, >=4.6.0` while `pyproject.toml` and `requirements*.txt` pinned `python-socketio==5.16.4`.

### Root Cause
`python-socketio` was bumped to `5.16.4` across dependency files without accounting for `metaapi-cloud-sdk`'s constraint range.

### Solution
Re-pinned `python-socketio` to `4.6.1` across `pyproject.toml` and `requirements*.txt`.

### Impact
- First-run `make bootstrap` completes cleanly without dependency errors.
- `make doctor` returns 🟢 `SYSTEM READY`.
- `make demo-synthetic` executes and outputs benchmark reports deterministically.

### Safety Check
No trading logic, risk management, model code, secrets, or deployment pipelines were modified.

---
*PR created automatically by Jules for task [16708272090316054741](https://jules.google.com/task/16708272090316054741) started by @triqbit*