### PR TITLE
docs: improve developer onboarding and contribution experience

### DIFF
--- a/docs/CONTRIBUTION_MAP.md
+++ b/docs/CONTRIBUTION_MAP.md
@@ -6,7 +6,7 @@ This map defines the "Safe Zones" and "Sensitive Zones" of the MT5 AI/ML Trading
 
 | Zone | Path | Risk Level | Review Requirement | Evidence Required |
 | :--- | :--- | :--- | :--- | :--- |
-| **Safe Zone** | `docs/`, `tests/`, `scripts/` | 🟢 Low | Standard Peer Review | Unit Tests / Doc Lint |
+| **Safe Zone** | `docs/`, `tests/`, `scripts/`, `Makefile` | 🟢 Low | Standard Peer Review | Unit Tests / Doc Lint |
 | **Utility Zone** | `src/utils/`, `src/analytics/` | 🟡 Medium | Domain Expert Review | Integration Tests |
 | **Sensitive Zone** | `src/trading/`, `src/models/`, `src/core/` | 🔴 High | Lead + Multi-Signature | Backtests + Stress Tests |
 
@@ -24,6 +24,11 @@ No. Past sandbox-specific warnings about "history grafting" were false-positives
 
 ### 3. How do I make sure my PR is aligned?
 Check the [Merge-Ready Checklist](./status/MERGE_READY_CHECKLIST.md) and keep your branch updated using `make resync` (or standard `git rebase`).
+
+### 4. What PR title format is required?
+Our CI enforces semantic PR titles via `.github/workflows/commit-check.yml`.
+- **Allowed prefixes:** `feat`, `fix`, `docs`, `chore`, `test`, `refactor`, `style`, `perf`, `ci`.
+- **Note:** Do NOT use non-standard prefixes like `DX:` in PR titles; use `docs:` for documentation/onboarding PRs or `chore:` for DX tool scripts.
 
 ---
 


### PR DESCRIPTION
1. Problem:
- New contributors lack clear guidance on whether Makefile edits belong in Safe Zones, and risk CI PR title failures when using non-standard prefixes like 'DX:'.

2. Root Cause:
- docs/CONTRIBUTION_MAP.md previously listed docs/, tests/, and scripts/ as Safe Zones without mentioning Makefile, and lacked explicit FAQ documentation on commit-check.yml semantic PR titling rules.

3. Solution:
- Updated docs/CONTRIBUTION_MAP.md to explicitly list Makefile under Safe Zones and added FAQ entry #4 explaining allowed semantic PR title prefixes (docs, chore, fix, etc.).

4. Impact:
- Reduces onboarding friction and prevents fast-validation CI title failures for first-time contributors.

5. Validation:
- Verified all relative links in documentation surfaces exist.
- Ran python3 -m unittest tests/test_triage_report.py tests/test_triage_heuristics.py cleanly.

6. Safety Check:
- Confirmed no trading logic, risk boundaries, or security/governance code was touched.

7. Remaining Gaps:
- None for this contribution-path improvement.

---
*PR created automatically by Jules for task [13905409797193697356](https://jules.google.com/task/13905409797193697356) started by @triqbit*