### PR TITLE
docs: update daily process integrity log [2026-08-30]

### DIFF
--- a/docs/status/PROCESS_INTEGRITY_LOG.md
+++ b/docs/status/PROCESS_INTEGRITY_LOG.md
@@ -2,6 +2,27 @@
 
 This log tracks the health and safety of the autonomous workflow for the `mt5-ai-xauusd-trader` repository.
 
+## 2026-08-30 18:00 GMT+4
+
+**Summary:** Process invariants are fully holding on `main`. No process drift or risky behavior detected. Two safe-surface daily PR triage dashboard and merge-readiness checklist update pull requests have been integrated since the last process integrity report.
+
+**Suspected Process Issues:**
+- **Stale PR Backlog:** The open PR count remains at 562. These are 100% stale relative to the active `main` branch but do not affect current system safety on `main`.
+
+**PRs/Commits Involved:**
+- `main` branch: Commit `df6e86d` (PR #1872) - Updates daily PR triage dashboard and merge-readiness checklist for 2026-08-30.
+- `main` branch: Commit `8679f4f` (PR #1871) - Updates daily merge-readiness checklist and PR triage dashboard for 2026-08-29.
+
+**Check Invariants:**
+- [x] Changes go through PRs (Verified: Integrated commits utilized proper PR branches).
+- [x] CI must pass before merge (Verified: Local developer diagnostics and heuristics tests pass cleanly, CI status is PASSING).
+- [x] Risky domains are not being changed casually (Verified: Only documentation, triage metrics, and checklist files were modified. No trading or risk logic files were touched).
+
+**Recommended Follow-ups:**
+- **Backlog Pruning:** Jules05 should perform a bulk prune/closure of the 562 stale PRs to reduce noise.
+
+**Status:** 🟢 GREEN (Invariants holding, git linear history verified as fully preserved).
+
 ## 2026-08-29 18:00 GMT+4
 
 **Summary:** Process invariants are fully holding on `main`. No process drift or risky behavior detected. One safe-surface daily PR triage dashboard update pull request has been integrated since the last process integrity report.


### PR DESCRIPTION
Update docs/status/PROCESS_INTEGRITY_LOG.md with daily process integrity report for 2026-08-30 18:00 GMT+4 documenting process invariants holding on main (🟢 GREEN).

---
*PR created automatically by Jules for task [7426850648396734839](https://jules.google.com/task/7426850648396734839) started by @triqbit*