### PR TITLE
docs: update daily PR triage dashboard [2026-08-31]

### DIFF
--- a/docs/status/MERGE_READY_CHECKLIST.md
+++ b/docs/status/MERGE_READY_CHECKLIST.md
@@ -1,9 +1,9 @@
 # Merge-Readiness Checklist
 
 > [!IMPORTANT]
-> **Critical Repository State Notice:** The `main` branch is currently operating under a linear git history model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `36f2f73ee4416fadd7c5c203b7dc6184d9398273` is required for all PRs.**
+> **Critical Repository State Notice:** The `main` branch is currently operating under a linear git history model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `98fa1f9bf31dfe6db3dbef3567bca333fc45eb75` is required for all PRs.**
 
-Generated on: 2026-08-30 14:20:57 UTC
+Generated on: 2026-08-31 13:22:24 UTC
 
 This checklist identifies top promising PRs for immediate review.
 
@@ -11,21 +11,21 @@ This checklist identifies top promising PRs for immediate review.
 - **Short scope summary**: Safe Surface update implementing 'docs: update process integrity log [2026-07-21]' (Candidate for re-validation/review)
 - **Domains touched**: docs
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `36f2f73ee4416fadd7c5c203b7dc6184d9398273`
+- **Missing items**: Mandatory rebase against commit `98fa1f9bf31dfe6db3dbef3567bca333fc45eb75`
 - **Recommendation**: Needs CI success before merge
 
 ## 2. PR #1661: DX: update process integrity log and project health [2026-07-14]
 - **Short scope summary**: Safe Surface update implementing 'DX: update process integrity log and project health [2026-07-14]' (Candidate for re-validation/review)
 - **Domains touched**: docs
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `36f2f73ee4416fadd7c5c203b7dc6184d9398273`
+- **Missing items**: Mandatory rebase against commit `98fa1f9bf31dfe6db3dbef3567bca333fc45eb75`
 - **Recommendation**: Needs CI success before merge
 
 ## 3. PR #1543: DX: improve developer onboarding and contribution experience
 - **Short scope summary**: Safe Surface update implementing 'DX: improve developer onboarding and contribution experience' (Candidate for re-validation/review)
 - **Domains touched**: docs
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `36f2f73ee4416fadd7c5c203b7dc6184d9398273`
+- **Missing items**: Mandatory rebase against commit `98fa1f9bf31dfe6db3dbef3567bca333fc45eb75`
 - **Recommendation**: Needs CI success before merge
 
 ---

--- a/docs/status/PR_TRIAGE_DAILY.md
+++ b/docs/status/PR_TRIAGE_DAILY.md
@@ -1,6 +1,6 @@
 # Daily PR Triage Dashboard
 
-**Date:** 2026-08-30 14:20:57 UTC
+**Date:** 2026-08-31 13:22:24 UTC
 **Status:** 🔴 HIGH TURBULENCE
 
 ### Turbulence Factors:
@@ -10,7 +10,7 @@
 
 ## 🔝 Top 3 Items That Matter Right Now
 
-1. **Mandatory Rebase:** All open PRs require a mandatory rebase against commit `36f2f73ee4416fadd7c5c203b7dc6184d9398273` to ensure compatibility.
+1. **Mandatory Rebase:** All open PRs require a mandatory rebase against commit `98fa1f9bf31dfe6db3dbef3567bca333fc45eb75` to ensure compatibility.
 2. **Address Turbulence:** High number of open PRs (562)
 3. **Re-validate Stale:** Review Safe Surface PR #1740 (docs: update daily merge-readiness checklist and PR triage [2026-07-31])
 


### PR DESCRIPTION
Executed daily PR intake & risk triage dashboard routine. Updated docs/status/PR_TRIAGE_DAILY.md and docs/status/MERGE_READY_CHECKLIST.md via scripts/generate_triage_report.py with updated open PR status and target commit SHA 98fa1f9bf31dfe6db3dbef3567bca333fc45eb75.

---
*PR created automatically by Jules for task [15198352718358702992](https://jules.google.com/task/15198352718358702992) started by @triqbit*