### PR TITLE
docs: update daily process integrity log [2026-08-31]

### DIFF
--- a/docs/status/PROCESS_INTEGRITY_LOG.md
+++ b/docs/status/PROCESS_INTEGRITY_LOG.md
@@ -2,6 +2,27 @@
 
 This log tracks the health and safety of the autonomous workflow for the `mt5-ai-xauusd-trader` repository.
 
+## 2026-08-31 18:00 GMT+4
+
+**Summary:** Process invariants are fully holding on `main`. No process drift or risky behavior detected. Two safe-surface daily PR triage dashboard and merge-readiness checklist update pull requests have been integrated since the last process integrity report.
+
+**Suspected Process Issues:**
+- **Stale PR Backlog:** The open PR count remains at 562. These are 100% stale relative to the active `main` branch but do not affect current system safety on `main`.
+
+**PRs/Commits Involved:**
+- `main` branch: Commit `a355a3e` (PR #1879) - Updates daily PR triage dashboard for 2026-08-31.
+- `main` branch: Commit `98fa1f9` (PR #1878) - Updates daily merge-readiness checklist for 2026-08-31.
+
+**Check Invariants:**
+- [x] Changes go through PRs (Verified: Integrated commits utilized proper PR branches).
+- [x] CI must pass before merge (Verified: Local developer diagnostics and heuristics tests pass cleanly, CI status is PASSING).
+- [x] Risky domains are not being changed casually (Verified: Only documentation, triage metrics, and checklist files were modified. No trading or risk logic files were touched).
+
+**Recommended Follow-ups:**
+- **Backlog Pruning:** Jules05 should perform a bulk prune/closure of the 562 stale PRs to reduce noise.
+
+**Status:** 🟢 GREEN (Invariants holding, git linear history verified as fully preserved).
+
 ## 2026-08-30 18:00 GMT+4
 
 **Summary:** Process invariants are fully holding on `main`. No process drift or risky behavior detected. Two safe-surface daily PR triage dashboard and merge-readiness checklist update pull requests have been integrated since the last process integrity report.


### PR DESCRIPTION
Updates the Daily Process Integrity & Drift Watcher log for 2026-08-31 in docs/status/PROCESS_INTEGRITY_LOG.md. Documents that process invariants are fully holding on main (STATUS: GREEN) following pull requests #1878 and #1879, with 562 stale PRs logged for backlog pruning by Jules05.

---
*PR created automatically by Jules for task [9529716101644953844](https://jules.google.com/task/9529716101644953844) started by @triqbit*