### PR TITLE
docs: update daily merge-readiness checklist and PR triage [2026-09-02]

### DIFF
--- a/docs/status/MERGE_READY_CHECKLIST.md
+++ b/docs/status/MERGE_READY_CHECKLIST.md
@@ -1,9 +1,9 @@
 # Merge-Readiness Checklist
 
 > [!IMPORTANT]
-> **Critical Repository State Notice:** The `main` branch is currently operating under a linear git history model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `9909ae4a87c1e4987975e62526441264491eb9d0` is required for all PRs.**
+> **Critical Repository State Notice:** The `main` branch is currently operating under a linear git history model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `cb08b44518f0614bfb9508b5a96c9d1293dda8ac` is required for all PRs.**
 
-Generated on: 2026-09-01 14:26:51 UTC
+Generated on: 2026-09-02 13:29:41 UTC
 
 This checklist identifies top promising PRs for immediate review.
 
@@ -11,21 +11,21 @@ This checklist identifies top promising PRs for immediate review.
 - **Short scope summary**: Safe Surface update implementing 'docs: update process integrity log [2026-07-21]' (Candidate for re-validation/review)
 - **Domains touched**: docs
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `9909ae4a87c1e4987975e62526441264491eb9d0`
+- **Missing items**: Mandatory rebase against commit `cb08b44518f0614bfb9508b5a96c9d1293dda8ac`
 - **Recommendation**: Needs CI success before merge
 
 ## 2. PR #1661: DX: update process integrity log and project health [2026-07-14]
 - **Short scope summary**: Safe Surface update implementing 'DX: update process integrity log and project health [2026-07-14]' (Candidate for re-validation/review)
 - **Domains touched**: docs
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `9909ae4a87c1e4987975e62526441264491eb9d0`
+- **Missing items**: Mandatory rebase against commit `cb08b44518f0614bfb9508b5a96c9d1293dda8ac`
 - **Recommendation**: Needs CI success before merge
 
 ## 3. PR #1543: DX: improve developer onboarding and contribution experience
 - **Short scope summary**: Safe Surface update implementing 'DX: improve developer onboarding and contribution experience' (Candidate for re-validation/review)
 - **Domains touched**: docs
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `9909ae4a87c1e4987975e62526441264491eb9d0`
+- **Missing items**: Mandatory rebase against commit `cb08b44518f0614bfb9508b5a96c9d1293dda8ac`
 - **Recommendation**: Needs CI success before merge
 
 ---

--- a/docs/status/PR_TRIAGE_DAILY.md
+++ b/docs/status/PR_TRIAGE_DAILY.md
@@ -1,6 +1,6 @@
 # Daily PR Triage Dashboard
 
-**Date:** 2026-09-01 14:26:51 UTC
+**Date:** 2026-09-02 13:29:41 UTC
 **Status:** 🔴 HIGH TURBULENCE
 
 ### Turbulence Factors:
@@ -10,7 +10,7 @@
 
 ## 🔝 Top 3 Items That Matter Right Now
 
-1. **Mandatory Rebase:** All open PRs require a mandatory rebase against commit `9909ae4a87c1e4987975e62526441264491eb9d0` to ensure compatibility.
+1. **Mandatory Rebase:** All open PRs require a mandatory rebase against commit `cb08b44518f0614bfb9508b5a96c9d1293dda8ac` to ensure compatibility.
 2. **Address Turbulence:** High number of open PRs (562)
 3. **Re-validate Stale:** Review Safe Surface PR #1740 (docs: update daily merge-readiness checklist and PR triage [2026-07-31])
 


### PR DESCRIPTION
Executed daily PR intake and risk triage dashboard routine for 2026-09-02. Updated `docs/status/PR_TRIAGE_DAILY.md` and `docs/status/MERGE_READY_CHECKLIST.md` via `scripts/generate_triage_report.py` with mandatory rebase target commit SHA `cb08b44518f0614bfb9508b5a96c9d1293dda8ac`. Verified report generation and triage unit tests pass cleanly.

---
*PR created automatically by Jules for task [6890592421887528493](https://jules.google.com/task/6890592421887528493) started by @triqbit*