### PR TITLE
chore(dx): improve developer onboarding and contribution experience

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "python-telegram-bot==22.8",
     "psutil==7.2.2",
     "optuna==4.9.0",
-    "python-socketio==5.16.4",
+    "python-socketio==4.6.1",
     "MetaTrader5==5.0.6147; sys_platform == 'win32'",
     "metaapi-cloud-sdk==29.1.1",
 ]

--- a/requirements-ci-no-talib.txt
+++ b/requirements-ci-no-talib.txt
@@ -22,7 +22,7 @@ pydantic-settings==2.15.0
 metaapi-cloud-sdk==29.1.1
 
 # -- Testing -------------------------------------------------------
-python-socketio==5.16.4
+python-socketio==4.6.1
 optuna==4.9.0
 pytest==9.1.1
 pytest-asyncio==1.4.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -25,7 +25,7 @@ pydantic-settings==2.15.0
 metaapi-cloud-sdk==29.1.1
 
 # -- Testing -------------------------------------------------------
-python-socketio==5.16.4
+python-socketio==4.6.1
 optuna==4.9.0
 pytest==9.1.1
 pytest-asyncio==1.4.0

--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -48,7 +48,7 @@ pydantic-settings==2.15.0
 tomli==2.4.1
 
 # -- Utilities -----------------------------------------------
-python-socketio==5.16.4
+python-socketio==4.6.1
 python-dateutil==2.9.0.post0
 nest-asyncio==1.6.0
 pytz==2026.3.post1

--- a/requirements-linux.txt
+++ b/requirements-linux.txt
@@ -61,7 +61,7 @@ ruff==0.16.5
 mypy==2.3.1
 
 # ── Utilities ───────────────────────────────────────────────
-python-socketio==5.16.4
+python-socketio==4.6.1
 python-dateutil==2.9.0.post0
 pytz==2026.3.post1
 click==8.5.0

--- a/requirements-temp.txt
+++ b/requirements-temp.txt
@@ -60,7 +60,7 @@ ruff==0.16.5
 mypy==2.3.1
 
 # ── Utilities ───────────────────────────────────────────────
-python-socketio==5.16.4
+python-socketio==4.6.1
 python-dateutil==2.9.0.post0
 pytz==2026.3.post1
 click==8.5.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -24,7 +24,7 @@ pydantic-settings==2.15.0
 metaapi-cloud-sdk==29.1.1
 
 # -- Testing -------------------------------------------------------
-python-socketio==5.16.4
+python-socketio==4.6.1
 optuna==4.9.0
 pytest==9.1.1
 pytest-asyncio==1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,7 +63,7 @@ ruff==0.16.5
 mypy==2.3.1
 
 # ── Utilities ───────────────────────────────────────────────
-python-socketio==5.16.4
+python-socketio==4.6.1
 python-dateutil==2.9.0.post0
 nest-asyncio==1.6.0
 pytz==2026.3.post1

--- a/scripts/doctor.py
+++ b/scripts/doctor.py
@@ -672,7 +672,7 @@ def _reexecute_in_venv_if_available():
         env = os.environ.copy()
         env["_DOCTOR_REEXEC"] = "1"
         try:
-            result = subprocess.run([str(venv_python)] + sys.argv, env=env)
+            result = subprocess.run([str(venv_python), *sys.argv], env=env)
             sys.exit(result.returncode)
         except Exception:
             pass


### PR DESCRIPTION
1. Problem:
Running 'make bootstrap' on clean setups failed with ResolutionImpossible due to python-socketio==5.16.4 conflicting with metaapi-cloud-sdk==29.1.1 (requires python-socketio<5.0.0,>=4.6.0). Additionally, scripts/doctor.py contained a Ruff RUF005 list concatenation lint violation on line 675.

2. Root Cause:
python-socketio was set to 5.16.4 across requirements files, breaking metaapi-cloud-sdk requirement bounds (<5.0.0, >=4.6.0). In scripts/doctor.py, line 675 used list concatenation [str(venv_python)] + sys.argv instead of list unpacking.

3. Solution:
Re-pinned python-socketio==4.6.1 across pyproject.toml and all 7 requirements*.txt files. Fixed Ruff RUF005 in scripts/doctor.py using list unpacking [str(venv_python), *sys.argv].

4. Impact:
'make bootstrap' completes cleanly out-of-the-box. 'make doctor' reports SYSTEM READY, and 'make demo-synthetic' executes deterministically.

5. Validation:
- make bootstrap: SUCCESS
- make doctor: SYSTEM READY
- make demo-synthetic: VERIFIED
- python3 scripts/verify_dependencies.py: HARMONIZED
- pytest tests/: 3 PASSED

6. Safety Check:
Confirmed no trading logic, risk management, model code, credentials, or security controls modified. Strictly limited to DX runtime surfaces.

7. Remaining Gaps:
None. Next runtime candidate is adding automatic pre-commit hook installer in bootstrap.sh.

---
*PR created automatically by Jules for task [229203952421304489](https://jules.google.com/task/229203952421304489) started by @triqbit*