### PR TITLE
docs: update daily process integrity log for 2026-09-06

### DIFF
--- a/docs/status/PROCESS_INTEGRITY_LOG.md
+++ b/docs/status/PROCESS_INTEGRITY_LOG.md
@@ -2,6 +2,26 @@
 
 This log tracks the health and safety of the autonomous workflow for the `mt5-ai-xauusd-trader` repository.
 
+## 2026-09-06 18:00 GMT+4
+
+**Summary:** Process invariants are fully holding on `main`. No process drift or risky behavior detected. One safe-surface daily PR intake and risk triage dashboard update pull request has been integrated since the last process integrity report.
+
+**Suspected Process Issues:**
+- **Stale PR Backlog:** The open PR count remains at 562. These are 100% stale relative to the active `main` branch but do not affect current system safety on `main`.
+
+**PRs/Commits Involved:**
+- `main` branch: Commit `1222acc` (PR #1900) - Updates daily PR intake and risk triage dashboard for 2026-09-06.
+
+**Check Invariants:**
+- [x] Changes go through PRs (Verified: Integrated commit utilized proper PR branch).
+- [x] CI must pass before merge (Verified: Local developer diagnostics and heuristics tests pass cleanly, CI status is PASSING).
+- [x] Risky domains are not being changed casually (Verified: Only documentation, triage metrics, and checklist files were modified. No trading or risk logic files were touched).
+
+**Recommended Follow-ups:**
+- **Backlog Pruning:** Jules05 should perform a bulk prune/closure of the 562 stale PRs to reduce noise.
+
+**Status:** 🟢 GREEN (Invariants holding, git linear history verified as fully preserved).
+
 ## 2026-09-05 18:00 GMT+4
 
 **Summary:** Process invariants are fully holding on `main`. No process drift or risky behavior detected. One safe-surface developer experience and contribution pathway pull request has been integrated since the last process integrity report.


### PR DESCRIPTION
Appends daily Process Integrity & Drift Watcher report for 2026-09-06 to docs/status/PROCESS_INTEGRITY_LOG.md. Verified that process invariants are fully holding on main (🟢 GREEN) following PR #1900, with zero modification to core trading/risk code. Verified clean execution of diagnostic unit tests.

---
*PR created automatically by Jules for task [2872472927719214755](https://jules.google.com/task/2872472927719214755) started by @triqbit*