### PR TITLE
docs: update daily merge-readiness checklist and triage report

### DIFF
--- a/docs/status/MERGE_READY_CHECKLIST.md
+++ b/docs/status/MERGE_READY_CHECKLIST.md
@@ -1,9 +1,9 @@
 # Merge-Readiness Checklist
 
 > [!IMPORTANT]
-> **Critical Repository State Notice:** The `main` branch is currently operating under a linear git history model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `b6327f910eb63e89a07048585bb0c380d408ecc0` is required for all PRs.**
+> **Critical Repository State Notice:** The `main` branch is currently operating under a linear git history model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `ff7efa2247826194871122492cb157ba7d391f39` is required for all PRs.**
 
-Generated on: 2026-09-06 13:17:09 UTC
+Generated on: 2026-09-06 14:13:32 UTC
 
 This checklist identifies top promising PRs for immediate review.
 
@@ -11,21 +11,21 @@ This checklist identifies top promising PRs for immediate review.
 - **Short scope summary**: Safe Surface update implementing 'docs: update process integrity log [2026-07-21]' (Candidate for re-validation/review)
 - **Domains touched**: docs
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `b6327f910eb63e89a07048585bb0c380d408ecc0`
+- **Missing items**: Mandatory rebase against commit `ff7efa2247826194871122492cb157ba7d391f39`
 - **Recommendation**: Needs CI success before merge
 
 ## 2. PR #1661: DX: update process integrity log and project health [2026-07-14]
 - **Short scope summary**: Safe Surface update implementing 'DX: update process integrity log and project health [2026-07-14]' (Candidate for re-validation/review)
 - **Domains touched**: docs
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `b6327f910eb63e89a07048585bb0c380d408ecc0`
+- **Missing items**: Mandatory rebase against commit `ff7efa2247826194871122492cb157ba7d391f39`
 - **Recommendation**: Needs CI success before merge
 
 ## 3. PR #1543: DX: improve developer onboarding and contribution experience
 - **Short scope summary**: Safe Surface update implementing 'DX: improve developer onboarding and contribution experience' (Candidate for re-validation/review)
 - **Domains touched**: docs
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `b6327f910eb63e89a07048585bb0c380d408ecc0`
+- **Missing items**: Mandatory rebase against commit `ff7efa2247826194871122492cb157ba7d391f39`
 - **Recommendation**: Needs CI success before merge
 
 ---

--- a/docs/status/PR_TRIAGE_DAILY.md
+++ b/docs/status/PR_TRIAGE_DAILY.md
@@ -1,6 +1,6 @@
 # Daily PR Triage Dashboard
 
-**Date:** 2026-09-06 13:17:09 UTC
+**Date:** 2026-09-06 14:13:32 UTC
 **Status:** 🔴 HIGH TURBULENCE
 
 ### Turbulence Factors:
@@ -10,7 +10,7 @@
 
 ## 🔝 Top 3 Items That Matter Right Now
 
-1. **Mandatory Rebase:** All open PRs require a mandatory rebase against commit `b6327f910eb63e89a07048585bb0c380d408ecc0` to ensure compatibility.
+1. **Mandatory Rebase:** All open PRs require a mandatory rebase against commit `ff7efa2247826194871122492cb157ba7d391f39` to ensure compatibility.
 2. **Address Turbulence:** High number of open PRs (562)
 3. **Re-validate Stale:** Review Safe Surface PR #1740 (docs: update daily merge-readiness checklist and PR triage [2026-07-31])
 


### PR DESCRIPTION
Updated docs/status/MERGE_READY_CHECKLIST.md and docs/status/PR_TRIAGE_DAILY.md via scripts/generate_triage_report.py with the current rebase target commit hash (ff7efa2247826194871122492cb157ba7d391f39). Verified formatting, guardrails (preventing 'safe to merge' wording), and unit tests cleanly.

---
*PR created automatically by Jules for task [8248885334436838464](https://jules.google.com/task/8248885334436838464) started by @triqbit*