### PR TITLE
docs: update daily merge-readiness checklist [2026-09-07]

### DIFF
--- a/docs/status/MERGE_READY_CHECKLIST.md
+++ b/docs/status/MERGE_READY_CHECKLIST.md
@@ -1,9 +1,9 @@
 # Merge-Readiness Checklist
 
 > [!IMPORTANT]
-> **Critical Repository State Notice:** The `main` branch is currently operating under a linear git history model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `0a535788acbecd0bf745e5713b0d0f2b394b1efe` is required for all PRs.**
+> **Critical Repository State Notice:** The `main` branch is currently operating under a linear git history model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `6a09d282fe155f7929232a0536a1d3c1bab67780` is required for all PRs.**
 
-Generated on: 2026-09-07 13:06:23 UTC
+Generated on: 2026-09-07 14:24:39 UTC
 
 This checklist identifies top promising PRs for immediate review.
 
@@ -11,21 +11,21 @@ This checklist identifies top promising PRs for immediate review.
 - **Short scope summary**: Medium Risk update implementing 'chore(deps): bump metatrader5 from 5.0.6147 to 5.0.6162' (Candidate for re-validation/review)
 - **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `0a535788acbecd0bf745e5713b0d0f2b394b1efe`, tests, docs
+- **Missing items**: Mandatory rebase against commit `6a09d282fe155f7929232a0536a1d3c1bab67780`, tests, docs
 - **Recommendation**: Needs CI success before merge
 
 ## 2. PR #1905: chore(deps): bump torch from 2.13.0+cpu to 2.14.0+cpu
 - **Short scope summary**: Safe Surface update implementing 'chore(deps): bump torch from 2.13.0+cpu to 2.14.0+cpu' (Candidate for re-validation/review)
 - **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `0a535788acbecd0bf745e5713b0d0f2b394b1efe`
+- **Missing items**: Mandatory rebase against commit `6a09d282fe155f7929232a0536a1d3c1bab67780`
 - **Recommendation**: Needs CI success before merge
 
 ## 3. PR #1697: docs: update process integrity log [2026-07-21]
 - **Short scope summary**: Safe Surface update implementing 'docs: update process integrity log [2026-07-21]' (Candidate for re-validation/review)
 - **Domains touched**: docs
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `0a535788acbecd0bf745e5713b0d0f2b394b1efe`
+- **Missing items**: Mandatory rebase against commit `6a09d282fe155f7929232a0536a1d3c1bab67780`
 - **Recommendation**: Needs CI success before merge
 
 ---

--- a/docs/status/PR_TRIAGE_DAILY.md
+++ b/docs/status/PR_TRIAGE_DAILY.md
@@ -1,6 +1,6 @@
 # Daily PR Triage Dashboard
 
-**Date:** 2026-09-07 13:06:23 UTC
+**Date:** 2026-09-07 14:24:39 UTC
 **Status:** 🔴 HIGH TURBULENCE
 
 ### Turbulence Factors:
@@ -10,7 +10,7 @@
 
 ## 🔝 Top 3 Items That Matter Right Now
 
-1. **Mandatory Rebase:** All open PRs require a mandatory rebase against commit `0a535788acbecd0bf745e5713b0d0f2b394b1efe` to ensure compatibility.
+1. **Mandatory Rebase:** All open PRs require a mandatory rebase against commit `6a09d282fe155f7929232a0536a1d3c1bab67780` to ensure compatibility.
 2. **Address Turbulence:** High number of open PRs (564)
 3. **Re-validate Stale:** Review Safe Surface PR #1905 (chore(deps): bump torch from 2.13.0+cpu to 2.14.0+cpu)
 


### PR DESCRIPTION
Updates `docs/status/MERGE_READY_CHECKLIST.md` and `docs/status/PR_TRIAGE_DAILY.md` via `scripts/generate_triage_report.py` for the daily 05:40 PM GMT+4 Merge-Ready Checklist routine.
- Updates candidate PR merge readiness checklists with the current rebase target commit `6a09d282fe155f7929232a0536a1d3c1bab67780`.
- Verified safety guardrails (preventing 'safe to merge' wording) via `/home/jules/self_created_tools/verify_merge_checklist.py`.
- Verified triage unit tests cleanly via `python3 -m unittest tests/test_triage_report.py tests/test_triage_heuristics.py`.

---
*PR created automatically by Jules for task [9039612930783088333](https://jules.google.com/task/9039612930783088333) started by @triqbit*