### PR TITLE
docs: update daily PR triage dashboard and merge checklist

### DIFF
--- a/docs/status/MERGE_READY_CHECKLIST.md
+++ b/docs/status/MERGE_READY_CHECKLIST.md
@@ -1,9 +1,9 @@
 # Merge-Readiness Checklist
 
 > [!IMPORTANT]
-> **Critical Repository State Notice:** The `main` branch is currently operating under a linear git history model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `6a09d282fe155f7929232a0536a1d3c1bab67780` is required for all PRs.**
+> **Critical Repository State Notice:** The `main` branch is currently operating under a linear git history model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `c6e7e5f532f71ba3f8a25e7b223897fe1df89d6c` is required for all PRs.**
 
-Generated on: 2026-09-07 14:24:39 UTC
+Generated on: 2026-09-08 13:22:05 UTC
 
 This checklist identifies top promising PRs for immediate review.
 
@@ -11,21 +11,21 @@ This checklist identifies top promising PRs for immediate review.
 - **Short scope summary**: Medium Risk update implementing 'chore(deps): bump metatrader5 from 5.0.6147 to 5.0.6162' (Candidate for re-validation/review)
 - **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `6a09d282fe155f7929232a0536a1d3c1bab67780`, tests, docs
+- **Missing items**: Mandatory rebase against commit `c6e7e5f532f71ba3f8a25e7b223897fe1df89d6c`, tests, docs
 - **Recommendation**: Needs CI success before merge
 
 ## 2. PR #1905: chore(deps): bump torch from 2.13.0+cpu to 2.14.0+cpu
 - **Short scope summary**: Safe Surface update implementing 'chore(deps): bump torch from 2.13.0+cpu to 2.14.0+cpu' (Candidate for re-validation/review)
 - **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `6a09d282fe155f7929232a0536a1d3c1bab67780`
+- **Missing items**: Mandatory rebase against commit `c6e7e5f532f71ba3f8a25e7b223897fe1df89d6c`
 - **Recommendation**: Needs CI success before merge
 
 ## 3. PR #1697: docs: update process integrity log [2026-07-21]
 - **Short scope summary**: Safe Surface update implementing 'docs: update process integrity log [2026-07-21]' (Candidate for re-validation/review)
 - **Domains touched**: docs
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `6a09d282fe155f7929232a0536a1d3c1bab67780`
+- **Missing items**: Mandatory rebase against commit `c6e7e5f532f71ba3f8a25e7b223897fe1df89d6c`
 - **Recommendation**: Needs CI success before merge
 
 ---

--- a/docs/status/PR_TRIAGE_DAILY.md
+++ b/docs/status/PR_TRIAGE_DAILY.md
@@ -1,6 +1,6 @@
 # Daily PR Triage Dashboard
 
-**Date:** 2026-09-07 14:24:39 UTC
+**Date:** 2026-09-08 13:22:05 UTC
 **Status:** 🔴 HIGH TURBULENCE
 
 ### Turbulence Factors:
@@ -10,7 +10,7 @@
 
 ## 🔝 Top 3 Items That Matter Right Now
 
-1. **Mandatory Rebase:** All open PRs require a mandatory rebase against commit `6a09d282fe155f7929232a0536a1d3c1bab67780` to ensure compatibility.
+1. **Mandatory Rebase:** All open PRs require a mandatory rebase against commit `c6e7e5f532f71ba3f8a25e7b223897fe1df89d6c` to ensure compatibility.
 2. **Address Turbulence:** High number of open PRs (564)
 3. **Re-validate Stale:** Review Safe Surface PR #1905 (chore(deps): bump torch from 2.13.0+cpu to 2.14.0+cpu)
 


### PR DESCRIPTION
Daily PR intake & risk triage dashboard update generated via scripts/generate_triage_report.py. Updates PR_TRIAGE_DAILY.md and MERGE_READY_CHECKLIST.md with open PR classification, risk levels, and candidates for review.

---
*PR created automatically by Jules for task [4810532715318159561](https://jules.google.com/task/4810532715318159561) started by @triqbit*