### PR TITLE
docs(status): update merge-ready checklist and triage daily status [2026-09-10]

### DIFF
--- a/docs/status/MERGE_READY_CHECKLIST.md
+++ b/docs/status/MERGE_READY_CHECKLIST.md
@@ -1,9 +1,9 @@
 # Merge-Readiness Checklist
 
 > [!IMPORTANT]
-> **Critical Repository State Notice:** The `main` branch is currently operating under a linear git history model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `46b76a69d66b51f19cfa89d3da5a7670fc6610cc` is required for all PRs.**
+> **Critical Repository State Notice:** The `main` branch is currently operating under a linear git history model. All merges must be carefully audited to ensure they do not accidentally overwrite or regress core logic from other active modules. **Mandatory rebase against commit `33d38e59465a76ffefe9876219d22b1b07fcaf0b` is required for all PRs.**
 
-Generated on: 2026-09-10 13:30:59 UTC
+Generated on: 2026-09-10 14:19:15 UTC
 
 This checklist identifies top promising PRs for immediate review.
 
@@ -11,21 +11,21 @@ This checklist identifies top promising PRs for immediate review.
 - **Short scope summary**: Medium Risk update implementing 'chore(deps): bump metatrader5 from 5.0.6147 to 5.0.6162' (Candidate for re-validation/review)
 - **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `46b76a69d66b51f19cfa89d3da5a7670fc6610cc`, tests, docs
+- **Missing items**: Mandatory rebase against commit `33d38e59465a76ffefe9876219d22b1b07fcaf0b`, tests, docs
 - **Recommendation**: Needs CI success before merge
 
 ## 2. PR #1905: chore(deps): bump torch from 2.13.0+cpu to 2.14.0+cpu
 - **Short scope summary**: Safe Surface update implementing 'chore(deps): bump torch from 2.13.0+cpu to 2.14.0+cpu' (Candidate for re-validation/review)
 - **Domains touched**: dependencies
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `46b76a69d66b51f19cfa89d3da5a7670fc6610cc`
+- **Missing items**: Mandatory rebase against commit `33d38e59465a76ffefe9876219d22b1b07fcaf0b`
 - **Recommendation**: Needs CI success before merge
 
 ## 3. PR #1697: docs: update process integrity log [2026-07-21]
 - **Short scope summary**: Safe Surface update implementing 'docs: update process integrity log [2026-07-21]' (Candidate for re-validation/review)
 - **Domains touched**: docs
 - **CI status**: pending
-- **Missing items**: Mandatory rebase against commit `46b76a69d66b51f19cfa89d3da5a7670fc6610cc`
+- **Missing items**: Mandatory rebase against commit `33d38e59465a76ffefe9876219d22b1b07fcaf0b`
 - **Recommendation**: Needs CI success before merge
 
 ---

--- a/docs/status/PR_TRIAGE_DAILY.md
+++ b/docs/status/PR_TRIAGE_DAILY.md
@@ -1,6 +1,6 @@
 # Daily PR Triage Dashboard
 
-**Date:** 2026-09-10 13:30:59 UTC
+**Date:** 2026-09-10 14:19:15 UTC
 **Status:** 🔴 HIGH TURBULENCE
 
 ### Turbulence Factors:
@@ -10,7 +10,7 @@
 
 ## 🔝 Top 3 Items That Matter Right Now
 
-1. **Mandatory Rebase:** All open PRs require a mandatory rebase against commit `46b76a69d66b51f19cfa89d3da5a7670fc6610cc` to ensure compatibility.
+1. **Mandatory Rebase:** All open PRs require a mandatory rebase against commit `33d38e59465a76ffefe9876219d22b1b07fcaf0b` to ensure compatibility.
 2. **Address Turbulence:** High number of open PRs (564)
 3. **Re-validate Stale:** Review Safe Surface PR #1905 (chore(deps): bump torch from 2.13.0+cpu to 2.14.0+cpu)
 


### PR DESCRIPTION
Executed the daily merge-ready checklist routine for 2026-09-10. Refreshed `docs/status/MERGE_READY_CHECKLIST.md` and `docs/status/PR_TRIAGE_DAILY.md` with candidate PR checklists, domain classifications, missing items, and review recommendations while upholding safety guardrails.

---
*PR created automatically by Jules for task [1485266020649028586](https://jules.google.com/task/1485266020649028586) started by @triqbit*