### PR TITLE
docs: improve developer onboarding and contribution experience

### DIFF
--- a/docs/audits/ADR_AUDIT_REPORT.md
+++ b/docs/audits/ADR_AUDIT_REPORT.md
@@ -51,6 +51,17 @@ This report documents the key architectural decisions governing the MT5 AI/ML Tr
 
 ---
 
+## 🔍 Evidence Routing & Technical Navigation
+
+| Evidence Artifact | Purpose | Status |
+| :--- | :--- | :--- |
+| [Technical Project Health Dashboard](../status/PROJECT_HEALTH.md) | Real-time visibility into technical debt, CI status, and PR backlog. | ✅ Active |
+| [Architecture Quick-Start](../ARCHITECTURE_QUICK.md) | 5-minute system overview and maturity map. | ✅ Verified |
+| [Enterprise Evidence Scorecard](./ENTERPRISE_EVIDENCE_SCORECARD.md) | Mapping of subsystem maturity to verified integration/audit evidence. | ✅ Active |
+| [Technical Audit Center](./README.md) | Central index of all verification and audit reports. | ✅ Active |
+
+---
+
 ## 🏛️ Governance Context
 
 This ADR Audit Report is maintained by **Jules06 (Technical Credibility & Evidence Surface Engine)**. It is updated weekly to reflect the current verified state of the repository's architectural foundation.

--- a/docs/status/PROJECT_HEALTH.md
+++ b/docs/status/PROJECT_HEALTH.md
@@ -7,7 +7,7 @@ This dashboard provides real-time visibility into the technical health, process 
 | Metric | Status | Note |
 | :--- | :--- | :--- |
 | **CI Success Rate** | 🟢 PASSING | 100% clean Ruff linter and formatter checks validated under local virtual environment. |
-| **PR Backlog** | 🔴 566 Stale | 100% of open PRs are stale relative to the latest active commit on `main`. |
+| **PR Backlog** | 🔴 564 Stale | 100% of open PRs are stale relative to the latest active commit on `main`. |
 | **Process Integrity** | 🟢 HEALTHY | Fully linear, intact git history with 1,260+ commits tracing back to root. |
 | **Evidence Maturity** | 🟢 **Active Verification** | Verified subsystem maturity in [Evidence Scorecard](../audits/ENTERPRISE_EVIDENCE_SCORECARD.md). |
 


### PR DESCRIPTION
1. Problem:
- Disconnect between architectural decisions documented in `docs/audits/ADR_AUDIT_REPORT.md` and direct technical evidence surfaces, making evidence discovery non-intuitive for auditing engineers.
- Minor drift in stale PR count in `docs/status/PROJECT_HEALTH.md`.

2. Root Cause:
- `docs/audits/ADR_AUDIT_REPORT.md` lacked direct cross-links to system health and architecture evidence dashboards.

3. Solution:
- Added a dedicated "Evidence Routing & Technical Navigation" section to `docs/audits/ADR_AUDIT_REPORT.md` linking to `PROJECT_HEALTH.md`, `ARCHITECTURE_QUICK.md`, `ENTERPRISE_EVIDENCE_SCORECARD.md`, and `docs/audits/README.md`.
- Updated stale PR backlog metric in `docs/status/PROJECT_HEALTH.md` to 564.

4. Impact:
- Improves first-trust navigation speed and evidence routing for technical stakeholders and enterprise auditors.

5. Validation:
- Ran `python3 -m unittest tests/test_triage_report.py tests/test_triage_heuristics.py` (Passed cleanly).
- Ran `python3 scripts/doctor.py` diagnostic tool.

6. Safety Check:
- Verified no trading logic, model research, testing internals, security controls, or deployment pipelines were modified.

7. Remaining Gaps:
- None for this weekly run.

---
*PR created automatically by Jules for task [4388754396235315966](https://jules.google.com/task/4388754396235315966) started by @triqbit*