### PR TITLE
docs: clarify semantic PR title lowercase subject rules and test commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ To help contributors start safely, system paths are categorized into clear revie
 ## 🚦 Quick Rules & Guidelines
 
 - **Keep Aligned:** Always rebase or synchronize your branch with the latest `main` commit before submitting (`make resync`).
-- **PR Title & Branch Rules:** CI enforces semantic PR titles (`docs:`, `chore:`, `test:`, `fix:`, `feat:`, `perf:`, `style:`, `refactor:`, `ci:`). **Do NOT use `DX:` prefix in PR titles or commits.**
+- **PR Title & Branch Rules:** CI enforces semantic PR titles (`docs:`, `chore:`, `test:`, `fix:`, `feat:`, `perf:`, `style:`, `refactor:`, `ci:`). **Subject must start with a lowercase letter** (e.g., `docs: improve guide` NOT `docs: Improve guide`). **Do NOT use `DX:` prefix in PR titles or commits.**
 - **Safe Zone Focus:** New contributors are strongly advised to start in `docs/`, `tests/`, or `scripts/` for a fast, friction-free path to merge.
 - **Multi-Signature:** Changes to Sensitive Zones (`src/trading/`, `src/models/`, `src/core/`) require multi-signature approval from domain leads.
 - **Quality Gates:** All PRs must pass automated linting, type-checking, security scans, and maintain high test coverage.

--- a/docs/CONTRIBUTION_MAP.md
+++ b/docs/CONTRIBUTION_MAP.md
@@ -28,6 +28,7 @@ Check the [Merge-Ready Checklist](./status/MERGE_READY_CHECKLIST.md) and keep yo
 ### 4. What PR title format is required?
 Our CI enforces semantic PR titles via `.github/workflows/commit-check.yml`.
 - **Allowed prefixes:** `feat`, `fix`, `docs`, `chore`, `test`, `refactor`, `style`, `perf`, `ci`.
+- **Subject Casing:** The subject after the prefix **must start with a lowercase letter** (e.g., `docs: improve guide`, NOT `docs: Improve guide`).
 - **Note:** Do NOT use non-standard prefixes like `DX:` in PR titles; use `docs:` for documentation/onboarding PRs or `chore:` for DX tool scripts.
 
 ---

--- a/docs/FIRST_REAL_CONTRIBUTION.md
+++ b/docs/FIRST_REAL_CONTRIBUTION.md
@@ -23,7 +23,8 @@ Our repository enforces a strict semantic pull request check using the `amannn/a
 > **Do NOT use the "DX:" prefix in your Pull Request Title or commit messages.**
 > Even though our developer experience team uses "DX" internally, the CI checker **rejects** the `DX:` prefix.
 >
-> **Allowed Semantic Prefixes:**
+> **Allowed Semantic Prefixes & Casing Rules:**
+> - The PR title subject after the prefix **must start with a lowercase letter** (e.g., `docs: improve developer guide` NOT `docs: Improve developer guide`).
 > - `docs:` for documentation and onboarding enhancements (e.g., `docs: improve developer onboarding guide`)
 > - `chore:` for developer tool scripts and auxiliary tasks (e.g., `chore: add directory validation check to doctor`)
 > - `test:` for writing or updating unit tests (e.g., `test: add unit tests for doctor checks`)


### PR DESCRIPTION
1. Problem:
First-time contributors experienced automated CI failures on pull request submission due to uppercase PR title subjects (e.g., `docs: Improve guide` instead of `docs: improve guide`), which are strictly rejected by `.github/workflows/commit-check.yml` (`amannn/action-semantic-pull-request`).

2. Root Cause:
While documentation previously warned against using non-semantic prefixes like `DX:`, it did not explicitly highlight the subject casing regex check enforcing lowercase starting letters after the semantic prefix.

3. Solution:
Updated `CONTRIBUTING.md`, `docs/CONTRIBUTION_MAP.md`, and `docs/FIRST_REAL_CONTRIBUTION.md` to explicitly document the lowercase subject starting requirement (`docs: improve guide` vs `docs: Improve guide`).

4. Impact:
Reduces onboarding friction for new contributors by preventing first-submission PR title CI rejections.

5. Validation:
Ran unit tests `python3 -m unittest tests/test_triage_report.py tests/test_triage_heuristics.py` cleanly. Verified documentation formatting and diffs.

6. Safety Check:
Only modified Safe Zone documentation files (`CONTRIBUTING.md`, `docs/CONTRIBUTION_MAP.md`, `docs/FIRST_REAL_CONTRIBUTION.md`). No trading, risk, model, security, or governance logic touched.

7. Remaining Gaps:
None for this safe contribution pathway update.

---
*PR created automatically by Jules for task [17819489717234282281](https://jules.google.com/task/17819489717234282281) started by @triqbit*